### PR TITLE
Prevent empty error divs from being generated on forms

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 0.5.8 - unreleased
 ------------------
 
+- Prevent empty error divs from being generated if errors are already associated
+  with a field.
+  [davidjb]
+
 0.5.7 - 2011-11-26
 ------------------
 

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -29,15 +29,15 @@
                     </dl>
                 </tal:status>
 
-                <div tal:define="errors view/widgets/errors" tal:condition="errors">
-                    <div tal:repeat="error errors"
-                         class="field error">
-                        <tal:block
-                            condition="not:nocall:error/widget"
-                            replace="structure error/render"
-                            />
-                    </div>
-                </div>
+                <tal:errors define="errors view/widgets/errors" condition="errors">
+                    <tal:error repeat="error errors">
+                        <div class="field error"
+                             tal:condition="not:nocall:error/widget"
+                             tal:content="structure error/render">
+                             Error
+                        </div>
+                    </tal:error>
+                </tal:errors>
 
                 <metal:description-slot define-slot="description">
                   <p  class="discreet"


### PR DESCRIPTION
At present, if errors happens on submission of a plone.app.z3cform, a number of error divs are created at the top of the form and they are empty if the error is associated with a given field.  Default Plone 4 theming sees the red outline of each of the given 'empty' error message divs.

This fix only displays the entire div if there is an error to be displayed.
