### PR TITLE
Update markup to use pat-inlinevalidation.

### DIFF
--- a/plone/app/z3cform/templates/multi_input.pt
+++ b/plone/app/z3cform/templates/multi_input.pt
@@ -9,7 +9,8 @@
                          key_error key_widget/error|nothing;
                          error_class python:(error or key_error) and ' error' or '';
                          fieldname_class string:kssattr-fieldname-${widget/name};"
-             tal:attributes="class string:multi-widget-field field z3cformInlineValidation ${fieldname_class}${error_class};
+             data-pat-inlinevalidation='{"type":"z3c.form"}'
+             tal:attributes="class string:multi-widget-field field pat-inlinevalidation ${fieldname_class}${error_class};
                              id string:formfield-${widget/id};">
 
             <input id="" name=""

--- a/plone/app/z3cform/templates/object_input.pt
+++ b/plone/app/z3cform/templates/object_input.pt
@@ -4,7 +4,8 @@
                          error widget/error;
                          error_class python:error and ' error' or '';
                          fieldname_class string:kssattr-fieldname-${widget/name};"
-             tal:attributes="class string:object-widget-field field z3cformInlineValidation ${fieldname_class}${error_class};
+             data-pat-inlinevalidation='{"type":"z3c.form"}'
+             tal:attributes="class string:object-widget-field field pat-inlinevalidation ${fieldname_class}${error_class};
              data-fieldname widget/name;
                              id string:formfield-${widget/id};">
 

--- a/plone/app/z3cform/templates/singlecheckbox.pt
+++ b/plone/app/z3cform/templates/singlecheckbox.pt
@@ -5,7 +5,8 @@
                error widget/error;
                error_class python:error and ' error' or '';
                fieldname_class string:kssattr-fieldname-${widget/name};"
-   tal:attributes="class string:field z3cformInlineValidation ${fieldname_class}${error_class};
+   data-pat-inlinevalidation='{"type":"z3c.form"}'
+   tal:attributes="class string:field pat-inlinevalidation ${fieldname_class}${error_class};
                    data-fieldname widget/name;
                    id string:formfield-${widget/id};">
 

--- a/plone/app/z3cform/templates/widget.pt
+++ b/plone/app/z3cform/templates/widget.pt
@@ -8,7 +8,8 @@
                empty_values python: (None, '', [], ('', '', '', '00', '00', ''), ('', '', ''));
                empty_class python: (widget.value in empty_values) and ' empty' or '';
                fieldname_class string:kssattr-fieldname-${widget/name};"
-   tal:attributes="class string:field z3cformInlineValidation ${fieldname_class}${error_class}${empty_class};
+   data-pat-inlinevalidation='{"type":"z3c.form"}'
+   tal:attributes="class string:field pat-inlinevalidation ${fieldname_class}${error_class}${empty_class};
                    data-fieldname widget/name;
                    id string:formfield-${widget/id};">
     <label for="" class="horizontal"


### PR DESCRIPTION
The old legacy JS code looked for the _z3cformInlineValidation_ class. Instead we now have a mockup pattern _pat-inlinevalidation_.

See Products.CMFPlone issues https://github.com/plone/Products.CMFPlone/issues/282 and https://github.com/plone/Products.CMFPlone/issues/299

Ping @vangheem 
