### PR TITLE
Remove redundant RichTextFieldWidget registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove the ``RichTextFieldWidget`` adapter registration, as it's redundant to
+  the one in ``plone.app.textfield``. This avoids zcml registration conflicts.
+  [thet]
 
 
 1.1.0 (2015-03-21)

--- a/plone/app/z3cform/configure.zcml
+++ b/plone/app/z3cform/configure.zcml
@@ -7,6 +7,7 @@
     i18n_domain="plone">
 
   <include package="plone.z3cform" />
+  <include package="plone.app.textfield"/>
   <include package="plone.app.widgets" />
   <include package=".wysiwyg" />
 
@@ -188,10 +189,6 @@
   <adapter factory=".widget.QueryStringFieldWidget"
            for="zope.schema.interfaces.IList
                 zope.schema.interfaces.IDict
-                z3c.form.interfaces.IFormLayer"/>
-
-  <adapter factory=".widget.RichTextFieldWidget"
-           for="plone.app.textfield.interfaces.IRichText
                 z3c.form.interfaces.IFormLayer"/>
 
 </configure>


### PR DESCRIPTION
Remove the ``RichTextFieldWidget`` adapter registration, as it's redundant to
the one in ``plone.app.textfield``. This avoids zcml registration conflicts.

@vangheem - ok with this? this pull-request removes the adapter registration, which is already registered in https://github.com/plone/plone.app.textfield/blob/master/plone/app/textfield/widget.py#L69

as described in https://github.com/plone/plone.app.z3cform/commit/850a18b393ab9a9388d985821401e2f9ddfb86b1 i got ZCML conflict errors when depending on Products.CMFPlone instead of Plone only.

for the other approach - using more specific browser layers - i created a branch: https://github.com/plone/plone.app.z3cform/tree/thet-iploneformlayer
but i think, this pull-request is the better one.