### PR TITLE
No need for unittest2

### DIFF
--- a/plone/app/z3cform/tests/test_objectsubform.py
+++ b/plone/app/z3cform/tests/test_objectsubform.py
@@ -9,7 +9,7 @@ from zope import interface, schema
 from zope import publisher
 from zope.globalrequest import setRequest
 
-import unittest2 as unittest
+import unittest
 
 
 class ISubObject(interface.Interface):

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -27,12 +27,7 @@ from plone.app.z3cform.widget import BaseWidget
 
 import mock
 import pytz
-
-try:
-    import unittest2 as unittest
-except ImportError:  # pragma: nocover
-    import unittest  # pragma: nocover
-    assert unittest  # pragma: nocover
+import unittest
 
 from Products.CMFPlone.interfaces import IMarkupSchema
 

--- a/plone/app/z3cform/tests/tests.py
+++ b/plone/app/z3cform/tests/tests.py
@@ -2,7 +2,7 @@ from plone.app.z3cform.tests.layer import PAZ3CForm_INTEGRATION_TESTING
 from plone.browserlayer.layer import mark_layer
 from zope.traversing.interfaces import BeforeTraverseEvent
 
-import unittest2 as unittest
+import unittest
 import zope.component.testing
 import zope.testing.doctest
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
             'plone.app.testing',
             'plone.browserlayer',
             'plone.testing',
-            'unittest2',
             'zope.contentprovider',
             'zope.publisher',
             'zope.testing',


### PR DESCRIPTION
Since python 2.7 unittest2 was already merged with unittest.