### PR TITLE
Allow time options to be customized for DatetimeWidget.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow time options to be customized for DatetimeWidget.
+  [thet]
 
 
 1.1.4 (2015-09-16)

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -178,7 +178,10 @@ class DatetimeWidgetTests(unittest.TestCase):
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
         self.field = Datetime(__name__='datetimefield')
         self.widget = DatetimeWidget(self.request)
-        self.widget.pattern_options = {'date': {'firstDay': 0}}
+        self.widget.pattern_options = {
+            'date': {'firstDay': 0},
+            'time': {'interval': 15}
+        }
 
     def test_widget(self):
         current_year = datetime.today().year
@@ -213,7 +216,8 @@ class DatetimeWidgetTests(unittest.TestCase):
                     'time': {
                         'placeholder': u'Enter time...',
                         'today': u'Today',
-                        'format': 'h:i a'
+                        'format': 'h:i a',
+                        'interval': 15
                     }
                 }
             },

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -183,7 +183,11 @@ class DatetimeWidget(DateWidget, HTMLInputWidget):
 
         args.setdefault('pattern_options', {})
         if 'time' in args['pattern_options']:
+            # Time gets set in parent class to false. Remove.
             del args['pattern_options']['time']
+        if 'time' in self.pattern_options:
+            # Re-apply custom set time options.
+            args['pattern_options']['time'] = self.pattern_options['time']
         args['pattern_options'] = dict_merge(
             get_datetime_options(self.request),
             args['pattern_options'])


### PR DESCRIPTION
that way, options can be customized by adapting the FieldWidget and set the pattern_options on it, as it can be done for other widgets too.