### PR TITLE
wrap context to allow tools to be found in text widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Wrap context to allow tools to be found in text widget.
+  [cguardia]
 
 
 1.1.4 (2015-09-16)

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from Acquisition import ImplicitAcquisitionWrapper
+from UserDict import UserDict
 from Products.CMFCore.utils import getToolByName
 from lxml import etree
 from plone.app.textfield.value import RichTextValue
@@ -15,6 +17,7 @@ from plone.app.widgets.utils import get_querystring_options
 from plone.app.widgets.utils import get_relateditems_options
 from plone.app.widgets.utils import get_tinymce_options
 from plone.registry.interfaces import IRegistry
+from plone.app.z3cform.utils import closest_content
 from z3c.form.browser.select import SelectWidget as z3cform_SelectWidget
 from z3c.form.browser.text import TextWidget as z3cform_TextWidget
 from z3c.form.browser.widget import HTMLInputWidget
@@ -449,6 +452,15 @@ class RichTextWidget(BaseWidget, patextfield_RichTextWidget):
         super(RichTextWidget, self).__init__(*args, **kwargs)
         self._pattern = None
 
+    def wrapped_context(self):
+        """"We need to wrap the context to be able to acquire the root
+            of the site to get tools, as done in plone.app.textfield"""
+        context = self.context
+        content = closest_content(context)
+        if context.__class__ == dict:
+            context = UserDict(self.context)
+        return ImplicitAcquisitionWrapper(context, content)
+
     @property
     def pattern(self):
         """dynamically grab the actual pattern name so it will
@@ -463,7 +475,7 @@ class RichTextWidget(BaseWidget, patextfield_RichTextWidget):
             except AttributeError:
                 default = 'tinymce'
                 available = ['TinyMCE']
-            tool = getToolByName(self.context, "portal_membership")
+            tool = getToolByName(self.wrapped_context(), "portal_membership")
             member = tool.getAuthenticatedMember()
             editor = member.getProperty('wysiwyg_editor')
             if editor in available:
@@ -476,7 +488,7 @@ class RichTextWidget(BaseWidget, patextfield_RichTextWidget):
     def _base_args(self):
         args = super(RichTextWidget, self)._base_args()
         args['name'] = self.name
-        properties = getToolByName(self.context, 'portal_properties')
+        properties = getToolByName(self.wrapped_context(), 'portal_properties')
         charset = properties.site_properties.getProperty('default_charset',
                                                          'utf-8')
         value = self.value and self.value.raw_encoded or ''


### PR DESCRIPTION
When the form context where the field is used does not have an acquisition chain to the root of the site, there is an attribute error with getToolByName. This affects products like collective.cover.

The text widget in plone.app.textfield did this context wrapping to avoid this type of issue, so I used the same strategy here.