### PR TITLE
fix: Check if user can add keywords for AjaxSelectWidget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Check if user can add keywords for AjaxSelectWidget.
+  [Gagaro]
 
 
 1.1.5 (2015-09-20)

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -340,6 +340,20 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
         if ISequence.providedBy(self.field) or self.orderable:
             args['pattern_options']['orderable'] = True
 
+        if self.vocabulary == 'plone.app.vocabularies.Keywords':
+            membership = getToolByName(context, 'portal_membership')
+            user = membership.getAuthenticatedMember()
+
+            registry = getUtility(IRegistry)
+            roles_allowed_to_add_keywords = registry.get(
+                'plone.roles_allowed_to_add_keywords', [])
+            roles = set(user.getRolesInContext(context))
+
+            allowNewItems = 'false'
+            if roles.intersection(roles_allowed_to_add_keywords):
+                allowNewItems = 'true'
+            args['pattern_options']['allowNewItems'] = allowNewItems
+
         return args
 
 


### PR DESCRIPTION
roles_allowed_to_add_keywords wasn't used at all for Dexterity.