### PR TITLE
in AjaxSelectWidget, allowNewItems should be false for Choice fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Don't allow adding new terms in the AjaxAutocompleteWidget
+  when it's used with a Choice field.
+  [davisagli]
 
 
 1.1.6 (2015-10-27)

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -754,6 +754,7 @@ class AjaxSelectWidgetTests(unittest.TestCase):
                 'pattern_options': {
                     'separator': ';',
                     'maximumSelectionSize': 1,
+                    'allowNewItems': 'false',
                     'vocabularyUrl':
                     'http://127.0.0.1/++widget++choicefield/@@getSource',
                     },

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -322,6 +322,8 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
             field = self.field
         elif ICollection.providedBy(self.field):
             field = self.field.value_type
+        if IChoice.providedBy(field):
+            args['pattern_options']['allowNewItems'] = 'false'
         if not vocabulary_name and field is not None:
             vocabulary_name = field.vocabularyName
 


### PR DESCRIPTION
Otherwise the widget lets you enter new terms, which will then fail validation.