### PR TITLE
Add metal slot for inserting stuff below fields

### DIFF
--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -143,6 +143,8 @@
                       </metal:define>
                     </metal:fields-slot>
 
+                    <metal:block define-slot="belowfields" />
+
                     <metal:actions-slot define-slot="actions">
                         <metal:define define-macro="actions">
                             <div class="formControls" tal:condition="view/actions/values|nothing">


### PR DESCRIPTION
It's currently not possible to insert any html by overriding the template on a form and using a fill-slot to insert something between the fields and the action buttons in a form. There's formtop and formbottom, but no belowfields. 

Example use case: we want to provide an extra snipped on a controlpanel form from plone.app.registry.browser.controlpanel, which generates everything for us, but it is almost impossible to add an extra text without resorting to inserting custom fields/etc.

Suggestions for a better name than 'belowfields' are appreciated.