### PR TITLE
Fixes related to RelatedItems Navigation Root Support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Fixes:
 - Use doctest instead of zope.testing.doctest
   [pbauer]
 
+- Fix related items widget tests to include root path support.
+  Fix options merging for TinyMCE widget.
+  [alecm]
 
 1.1.8 (2016-01-08)
 ------------------

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -765,7 +765,7 @@ class AjaxSelectWidgetTests(unittest.TestCase):
     def test_widget_addform_url_on_addform(self):
         from plone.app.z3cform.widget import AjaxSelectWidget
         widget = AjaxSelectWidget(self.request)
-        form = Mock()
+        form = Mock(parentForm=None)
         from zope.interface import directlyProvides
         from z3c.form.interfaces import IAddForm
         directlyProvides(form, IAddForm)
@@ -945,7 +945,8 @@ class RelatedItemsWidgetTests(unittest.TestCase):
     def test_widget(self):
         from plone.app.z3cform.widget import RelatedItemsWidget
         widget = RelatedItemsWidget(self.request)
-        widget.context = Mock(absolute_url=lambda: 'fake_url')
+        widget.context = Mock(absolute_url=lambda: 'fake_url',
+                              getPhysicalPath=lambda: ['', 'site'])
         widget.update()
         self.assertEqual(
             {
@@ -958,8 +959,9 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'searchAllText': u'Entire site',
                     'searchText': u'Search',
                     'separator': ';',
-                    'vocabularyUrl': '/@@getVocabulary?name='
+                    'vocabularyUrl': 'fake_url/@@getVocabulary?name='
                                      'plone.app.vocabularies.Catalog',
+                    'rootPath': '/site',
                 },
             },
             widget._base_args()
@@ -969,7 +971,8 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         """The pattern_options value for maximumSelectionSize should
         be 1 when the field only allows a single selection."""
         from plone.app.z3cform.widget import RelatedItemsFieldWidget
-        context = Mock(absolute_url=lambda: 'fake_url')
+        context = Mock(absolute_url=lambda: 'fake_url',
+                       getPhysicalPath=lambda: ['', 'site'])
         field = Choice(
             __name__='selectfield',
             values=['one', 'two', 'three'],
@@ -988,7 +991,8 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         from zope.schema.interfaces import ISource
         from zope.schema.vocabulary import VocabularyRegistry
 
-        context = Mock(absolute_url=lambda: 'fake_url')
+        context = Mock(absolute_url=lambda: 'fake_url',
+                       getPhysicalPath=lambda: ['', 'site'])
         field = List(
             __name__='selectfield',
             value_type=Choice(vocabulary='foobar')
@@ -1005,7 +1009,7 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         self.assertFalse('maximumSelectionSize' in patterns_options)
         self.assertEqual(
             patterns_options['vocabularyUrl'],
-            '/@@getVocabulary?name=foobar&field=selectfield',
+            'fake_url/@@getVocabulary?name=foobar&field=selectfield',
             )
 
     def test_converter_RelationChoice(self):


### PR DESCRIPTION
Fix related items widget tests to include root path support. Fix options merging for TinyMCE widget.
Ensure vocabulary lookup works on non-EditForms.
Allow overriding widget pattern_options dynamically using ComputedWidgetAttribute.