### PR TITLE
fix: relateditems test for plone.app.widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Fixes:
 - Fixed test for plone.app.widgets.
   [Gagaro]
 
+- Used assertDictEqual instead of assertEqual for RelatedItemsWidgetTests.test_widget
+  [Gagaro]
+
 1.1.8 (2016-01-08)
 ------------------
 

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -948,7 +948,7 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         widget.context = Mock(absolute_url=lambda: 'fake_url',
                               getPhysicalPath=lambda: ['', 'site'])
         widget.update()
-        self.assertEqual(
+        self.assertDictEqual(
             {
                 'name': None,
                 'value': u'',
@@ -964,6 +964,8 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'rootPath': '/site',
                     'treeVocabularyUrl':  '/@@getVocabulary?name='
                                           'plone.app.vocabularies.Catalog',
+                    'sort_on': 'sortable_title',
+                    'sort_order': 'ascending'
                 },
             },
             widget._base_args()


### PR DESCRIPTION
Fix a test for https://github.com/plone/plone.app.widgets/pull/132 and use assertDictEqual (dict are not ordered and assertEqual compare them as string).