### PR TITLE
Allow to set CSS class via plone.autoform directives

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Don't overwrite widget default css classes when rendering pattern widgets.
+  This allows setting a css class via the ``klass`` keyword in plone.autoform widget directives.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -99,6 +99,20 @@ class BaseWidgetTests(unittest.TestCase):
             '<input class="pat-example" type="text"/>',
             widget.render())
 
+    def test_widget_base_custom_css(self):
+        from plone.app.z3cform.widget import BaseWidget
+        from plone.app.widgets.base import InputWidget
+
+        widget = BaseWidget(self.request)
+        widget.field = self.field
+        widget.pattern = 'example'
+        widget.klass = 'very-custom-class'
+        widget._base = InputWidget
+
+        self.assertEqual(
+            '<input class="pat-example very-custom-class" type="text"/>',
+            widget.render())
+
 
 class DateWidgetTests(unittest.TestCase):
 

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -90,7 +90,13 @@ class BaseWidget(Widget):
         """
         if self.mode != 'input':
             return super(BaseWidget, self).render()
-        return self._base(**self._base_args()).render()
+
+        pattern_widget = self._base(**self._base_args())
+        if getattr(self, 'klass', False):
+            pattern_widget.klass = u'{0} {1}'.format(
+                pattern_widget.klass, self.klass
+            )
+        return pattern_widget.render()
 
 
 @implementer_only(IDateWidget)


### PR DESCRIPTION
- Set the ``firstDay`` option on the ``DatetimeWidget`` likewise as ``DateWidget``.
- Don't overwrite widget default css classes when rendering pattern widgets.
  This allows setting a css class via the ``klass`` keyword in plone.autoform widget directives.