### PR TITLE
Call callables in pattern options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Breaking changes:
 
 New features:
 
+- Support functions as values in the ``pattern_options`` dictionary, whch gets then serialized to JSON.
+  Before that, walk recursively through ``pattern_options`` and call all functions with the widgets context.
+  This allows for context-specific, runtime evaluated pattern option values.
+  [thet]
+
 - Don't overwrite widget default css classes when rendering pattern widgets.
   This allows setting a css class via the ``klass`` keyword in plone.autoform widget directives.
   [thet]

--- a/plone/app/z3cform/tests/test_utils.py
+++ b/plone/app/z3cform/tests/test_utils.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+
+class TestUnitCallCallables(unittest.TestCase):
+
+    def test_simple(self):
+        from plone.app.z3cform.utils import call_callables
+
+        test_in = 1
+        test_compare = 1
+        test_out = call_callables(
+            test_in,
+            'funny return value'
+        )
+        self.assertEqual(test_out, test_compare)
+
+    def test_simple_function(self):
+        from plone.app.z3cform.utils import call_callables
+
+        test_in = lambda x: x
+        test_compare = 'funny return value'
+        test_out = call_callables(
+            test_in,
+            'funny return value'
+        )
+        self.assertEqual(test_out, test_compare)
+
+    def test_list(self):
+        from plone.app.z3cform.utils import call_callables
+
+        test_in = [1, 2, 3, lambda x: x]
+        test_compare = [1, 2, 3, 'funny return value']
+        test_out = call_callables(
+            test_in,
+            'funny return value'
+        )
+        self.assertEqual(test_out, test_compare)
+
+    def test_tuple(self):
+        from plone.app.z3cform.utils import call_callables
+
+        test_in = (1, 2, 3, lambda x: x)
+        test_compare = (1, 2, 3, 'funny return value')
+        test_out = call_callables(
+            test_in,
+            'funny return value'
+        )
+        self.assertEqual(test_out, test_compare)
+
+    def test_complex(self):
+        from plone.app.z3cform.utils import call_callables
+
+        test_in = {
+            'normal': 123,
+            'list': [1, 2, 3, lambda x: x, [11, 22, 33, lambda x: x, (44, 55, 66, lambda x: x)]],  # noqa
+            'tuple': (1, 2, 3, lambda x: x, (11, 22, 33, lambda x: x, [44, 55, 66, lambda x: x])),  # noqa
+            'dict': {
+                'subnormal': 456,
+                'sublist': [4, 5, 6, lambda x: x],
+                'subtuple': (4, 5, 6, lambda x: x),
+                'subdict': {
+                    'subsubnormal': 789,
+                    'subsublist': [7, 8, 9, lambda x: x],
+                    'subsubtuple': (7, 8, 9, lambda x: x),
+                }
+            }
+        }
+
+        test_compare = {
+            'normal': 123,
+            'list': [1, 2, 3, 'funny return value', [11, 22, 33, 'funny return value', (44, 55, 66, 'funny return value')]],  # noqa
+            'tuple': (1, 2, 3, 'funny return value', (11, 22, 33, 'funny return value', [44, 55, 66, 'funny return value'])),  # noqa
+            'dict': {
+                'subnormal': 456,
+                'sublist': [4, 5, 6, 'funny return value'],
+                'subtuple': (4, 5, 6, 'funny return value'),
+                'subdict': {
+                    'subsubnormal': 789,
+                    'subsublist': [7, 8, 9, 'funny return value'],
+                    'subsubtuple': (7, 8, 9, 'funny return value'),
+                }
+            }
+        }
+
+        test_out = call_callables(
+            test_in,
+            'funny return value'
+        )
+
+        self.assertEqual(test_out, test_compare)
+
+
+def test_suite():
+    return unittest.TestSuite([
+        unittest.makeSuite(TestUnitCallCallables),
+    ])

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -113,6 +113,31 @@ class BaseWidgetTests(unittest.TestCase):
             '<input class="pat-example very-custom-class" type="text"/>',
             widget.render())
 
+    def test_widget_base_pattern_options_with_functions(self):
+        from plone.app.z3cform.widget import BaseWidget
+        from plone.app.widgets.base import InputWidget
+
+        widget = BaseWidget(self.request)
+        widget.context = 'testcontext'
+        widget.field = self.field
+        widget.pattern = 'example'
+        widget._base = InputWidget
+        widget.pattern_options = {
+            'subdict': {
+                'subsubnormal': 789,
+                'subsublist': [7, 8, 9, lambda x: x],
+                'subsubtuple': (7, 8, 9, lambda x: x),
+            }
+        }
+
+        self.assertEqual(
+            '<input class="pat-example" type="text" '
+            'data-pat-example="{&quot;subdict&quot;: '
+            '{&quot;subsubtuple&quot;: [7, 8, 9, &quot;testcontext&quot;], '
+            '&quot;subsublist&quot;: [7, 8, 9, &quot;testcontext&quot;], '
+            '&quot;subsubnormal&quot;: 789}}"/>',
+            widget.render())
+
 
 class DateWidgetTests(unittest.TestCase):
 

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -48,3 +48,28 @@ def _valid_context(context):
         context = parent
 
     return None
+
+
+def call_callables(value, *args, **kwargs):
+    """Walk recursively through data structure and call all callables, passing
+    the arguments and keyword arguments to it.
+    """
+    ret = value
+    if callable(value):
+        ret = value(*args, **kwargs)
+    elif isinstance(value, list):
+        ret = [
+            call_callables(v, *args, **kwargs)
+            for v in value
+        ]
+    elif isinstance(value, tuple):
+        ret = tuple(
+            call_callables(v, *args, **kwargs)
+            for v in value
+        )
+    elif isinstance(value, dict):
+        ret = {
+            k: call_callables(v, *args, **kwargs)
+            for k, v in value.items()
+        }
+    return ret

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -25,6 +25,7 @@ from plone.app.z3cform.interfaces import IQueryStringWidget
 from plone.app.z3cform.interfaces import IRelatedItemsWidget
 from plone.app.z3cform.interfaces import IRichTextWidget
 from plone.app.z3cform.interfaces import ISelectWidget
+from plone.app.z3cform.utils import call_callables
 from plone.app.z3cform.utils import closest_content
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
@@ -91,7 +92,13 @@ class BaseWidget(Widget):
         if self.mode != 'input':
             return super(BaseWidget, self).render()
 
-        pattern_widget = self._base(**self._base_args())
+        _base_args = self._base_args()
+        _base_args['pattern_options'] = call_callables(
+            _base_args['pattern_options'],
+            self.context
+        )
+
+        pattern_widget = self._base(**_base_args)
         if getattr(self, 'klass', False):
             pattern_widget.klass = u'{0} {1}'.format(
                 pattern_widget.klass, self.klass


### PR DESCRIPTION
Support functions as values in the ``pattern_options`` dictionary, whch gets then serialized to JSON.
Before that, walk recursively through ``pattern_options`` and call all functions with the widgets context.
This allows for context-specific, runtime evaluated pattern option values.