### PR TITLE
Related items data converter fix with tests: supports explicit value_…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ New features:
 
 - Related items data converter supports explicit value_type specified in
   field when using collections of UUID values.  This is backward-compatible
-  with previous conversion to field values.
+  with previous conversion to field values, supports str/unicode value(s),
+  whichever is specified by field.
   [seanupton]
 
 - Support functions as values in the ``pattern_options`` dictionary, whch gets then serialized to JSON.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Breaking changes:
 
 New features:
 
+- Related items data converter supports explicit value_type specified in
+  field when using collections of UUID values.  This is backward-compatible
+  with previous conversion to field values.
+  [seanupton]
+
 - Support functions as values in the ``pattern_options`` dictionary, whch gets then serialized to JSON.
   Before that, walk recursively through ``pattern_options`` and call all functions with the widgets context.
   This allows for context-specific, runtime evaluated pattern option values.

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -265,8 +265,6 @@ class RelatedItemsDataConverter(BaseDataConverter):
                                   if uid in objects.keys())
         else:
             valueType = getattr(self.field.value_type, '_type', unicode)
-            if isinstance(valueType, tuple):
-                valueType = self.field.value_type[-1]
             return collectionType(valueType(v) for v in value)
 
 

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -264,7 +264,10 @@ class RelatedItemsDataConverter(BaseDataConverter):
                                   for uid in value
                                   if uid in objects.keys())
         else:
-            return collectionType(v for v in value)
+            valueType = getattr(self.field.value_type, '_type', unicode)
+            if isinstance(valueType, tuple):
+                valueType = self.field.value_type[-1]
+            return collectionType(valueType(v) for v in value)
 
 
 @adapter(IList, IQueryStringWidget)

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -19,6 +19,7 @@ from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import Interface
 from zope.publisher.browser import TestRequest as BaseTestRequest
+from zope.schema import BytesLine
 from zope.schema import Choice
 from zope.schema import Date
 from zope.schema import Datetime
@@ -1069,7 +1070,7 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': EXPECTED_VOCAB_URL,
                     'rootPath': EXPECTED_ROOT_PATH,
                     'basePath': EXPECTED_BASE_PATH,
-                    'treeVocabularyUrl':  EXPECTED_TREE_URL,
+                    'treeVocabularyUrl': EXPECTED_TREE_URL,
                     'sort_on': 'sortable_title',
                     'sort_order': 'ascending'
                 },
@@ -1140,7 +1141,7 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': EXPECTED_VOCAB_URL,
                     'rootPath': EXPECTED_ROOT_PATH,
                     'basePath': EXPECTED_BASE_PATH,
-                    'treeVocabularyUrl':  EXPECTED_TREE_URL,
+                    'treeVocabularyUrl': EXPECTED_TREE_URL,
                     'sort_on': 'sortable_title',
                     'sort_order': 'ascending'
                 },
@@ -1243,17 +1244,29 @@ class RelatedItemsWidgetTests(unittest.TestCase):
 
     def test_converter_List_of_Choice(self):
         from plone.app.z3cform.converters import RelatedItemsDataConverter
-        field = List()
-        widget = Mock(separator=';')
-        converter = RelatedItemsDataConverter(field, widget)
+        fields = (
+            List(),
+            List(value_type=TextLine()),
+            List(value_type=BytesLine()),
+            )
+        for field in fields:
+            expected_value_type = getattr(field.value_type, '_type', unicode)
+            widget = Mock(separator=';')
+            converter = RelatedItemsDataConverter(field, widget)
 
-        self.assertEqual(converter.toWidgetValue(None), None)
-        self.assertEqual(
-            converter.toWidgetValue(['id1', 'id2']), 'id1;id2')
+            self.assertEqual(converter.toWidgetValue(None), None)
+            self.assertEqual(
+                converter.toWidgetValue(['id1', 'id2']), 'id1;id2')
 
-        self.assertEqual(converter.toFieldValue(None), None)
-        self.assertEqual(
-            converter.toFieldValue('id1;id2'), ['id1', 'id2'])
+            self.assertEqual(converter.toFieldValue(None), None)
+            self.assertEqual(
+                converter.toFieldValue('id1;id2'), ['id1', 'id2'])
+
+            self.assertEqual(converter.toFieldValue(None), None)
+            self.assertEqual(
+                type(converter.toFieldValue('id1;id2')[0]),
+                expected_value_type
+                )
 
     def test_fieldwidget(self):
         from plone.app.z3cform.widget import RelatedItemsWidget


### PR DESCRIPTION
…type specified in field when using collections of UUID values.  This is backward-compatible with previous conversion to field values.

Add-ons using collection of BytesLine values for UUIDs break without this fix, when using the mockup related items widget (which has strings submitted in JSON marshalled to unicode without regard to actual/declared field value type).  This PR addresses that, and is backward compatible with existing default behavior (allowing use of TextLine/unicode or BytesLine/str to store UUID values).