### PR TITLE
Helps avoid TypeError InterfaceClass plone.uuid.interfaces.IUUID

### DIFF
--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -228,7 +228,7 @@ class RelatedItemsDataConverter(BaseDataConverter):
             return self.field.missing_value
         separator = getattr(self.widget, 'separator', ';')
         if IRelationList.providedBy(self.field):
-            return separator.join([IUUID(o) for o in value if value])
+            return separator.join([IUUID(o) for o in value if value and o])
         else:
             return separator.join(v for v in value if v)
 


### PR DESCRIPTION
Helps avoid TypeError: ('Could not adapt', None, <InterfaceClass plone.uuid.interfaces.IUUID>) error if any in the past related objects were deleted.