### PR TITLE
RelatedItemsDataConverter fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix RelatedItemsDataConverter with relation lists, where in an iteration a wrong value was checked to be existent.
+  Fixes failures in situations, where a ``None`` value was part of the relation list.
+  [thet]
 
 
 2.1.2 (2016-12-02)

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -228,7 +228,7 @@ class RelatedItemsDataConverter(BaseDataConverter):
             return self.field.missing_value
         separator = getattr(self.widget, 'separator', ';')
         if IRelationList.providedBy(self.field):
-            return separator.join([IUUID(o) for o in value if value])
+            return separator.join([IUUID(o) for o in value if o])
         else:
             return separator.join(v for v in value if v)
 


### PR DESCRIPTION
Fix RelatedItemsDataConverter with relation lists, where in an iteration a wrong value was checked to be existent.
Fixes failures in situations, where a ``None`` value was part of the relation list.

Looks like, the problem was introduced when the converter code was copied over from plone.app.widgets. p.a.w 1.x branch does it right:
https://github.com/plone/plone.app.widgets/blob/1.x/plone/app/widgets/dx.py#L335

Note the PR for 1.x branch: https://github.com/plone/plone.app.z3cform/pull/56