### PR TITLE
Fix issue where RelatedItemsDataConverter failed to convert list of choices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Bug fixes:
   Fixes failures in situations, where a ``None`` value was part of the relation list.
   [thet]
 
+- Fix RelatedItemsDataConverter with choice lists, where choices are UUID
+  strings of selected relations, but conversion failed, because Choice
+  field has None as its value_type
+  [datakurre]
+
 
 2.1.2 (2016-12-02)
 ------------------

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -265,6 +265,8 @@ class RelatedItemsDataConverter(BaseDataConverter):
                                   if uid in objects.keys())
         else:
             valueType = getattr(self.field.value_type, '_type', unicode)
+            if valueType is None:
+                valueType = unicode
             return collectionType(valueType(v) for v in value)
 
 

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -1187,9 +1187,12 @@ class RelatedItemsWidgetTests(unittest.TestCase):
             List(),
             List(value_type=TextLine()),
             List(value_type=BytesLine()),
+            List(value_type=Choice(values=['one', 'two', 'three']))
             )
         for field in fields:
             expected_value_type = getattr(field.value_type, '_type', unicode)
+            if expected_value_type is None:
+                expected_value_type = unicode
             widget = Mock(separator=';')
             converter = RelatedItemsDataConverter(field, widget)
 


### PR DESCRIPTION
because of choice value type being None

For example, the following widget works only after this change.

```
    <field type="zope.schema.List" name="paths"
           form:widget="plone.app.z3cform.widget.RelatedItemsFieldWidget">
      <title i18n:ranslate="">Searchable folders</title>
      <required>False</required>
      <value_type type="zope.schema.Choice">
        <source>path.to.instance.of.plone.app.vocabularies.catalog.CatalogSource</source>
      </value_type>
    </field>
```
