### PR TITLE
pickadate optimizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Test fixes for plone.app.widgets 2.1.
+  [thet]
+
 - remove deprecated __of__ for browserviews
   [pbauer]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Do not show the "Clear" button for required Date or DateTime fields.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -148,6 +148,7 @@ class DateWidgetTests(unittest.TestCase):
 
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
         self.field = Date(__name__='datefield')
+        self.field.required = False
         self.widget = DateWidget(self.request)
         self.widget.field = self.field
         self.widget.pattern_options = {'date': {'firstDay': 0}}
@@ -187,6 +188,13 @@ class DateWidgetTests(unittest.TestCase):
             },
             self.widget._base_args(),
         )
+
+    def test_widget_required(self):
+        """Required fields should not have a "Clear" button.
+        """
+        self.field.required = True
+        base_args = self.widget._base_args()
+        self.assertEqual(base_args['pattern_options']['clear'], False)
 
     def test_data_converter(self):
         from plone.app.z3cform.widget import DateWidgetConverter
@@ -240,7 +248,9 @@ class DatetimeWidgetTests(unittest.TestCase):
 
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
         self.field = Datetime(__name__='datetimefield')
+        self.field.required = False
         self.widget = DatetimeWidget(self.request)
+        self.widget.field = self.field
         self.widget.pattern_options = {
             'date': {'firstDay': 0},
             'time': {'interval': 15}
@@ -285,6 +295,13 @@ class DatetimeWidgetTests(unittest.TestCase):
             },
             self.widget._base_args(),
         )
+
+    def test_widget_required(self):
+        """Required fields should not have a "Clear" button.
+        """
+        self.field.required = True
+        base_args = self.widget._base_args()
+        self.assertEqual(base_args['pattern_options']['clear'], False)
 
     def test_data_converter(self):
         from plone.app.z3cform.widget import DatetimeWidgetConverter

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -164,7 +164,6 @@ class DateWidgetTests(unittest.TestCase):
                         'firstDay': 0,
                         'min': [current_year - 100, 1, 1],
                         'max': [current_year + 20, 1, 1],
-                        'clear': u'Clear',
                         'format': 'mmmm d, yyyy',
                         'monthsFull': [u'January', u'February', u'March',
                                        u'April', u'May', u'June', u'July',
@@ -175,14 +174,15 @@ class DateWidgetTests(unittest.TestCase):
                         'weekdaysFull': [u'Sunday', u'Monday', u'Tuesday',
                                          u'Wednesday', u'Thursday', u'Friday',
                                          u'Saturday'],
-                        'today': u'Today',
                         'selectYears': 200,
                         'placeholder': u'Enter date...',
                         'monthsShort': [u'Jan', u'Feb', u'Mar', u'Apr', u'May',
                                         u'Jun', u'Jul', u'Aug', u'Sep', u'Oct',
                                         u'Nov', u'Dec']
                     },
-                    'time': False
+                    'time': False,
+                    'today': u'Today',
+                    'clear': u'Clear',
                 }
             },
             self.widget._base_args(),
@@ -258,7 +258,6 @@ class DatetimeWidgetTests(unittest.TestCase):
                         'firstDay': 0,
                         'min': [current_year - 100, 1, 1],
                         'max': [current_year + 20, 1, 1],
-                        'clear': u'Clear',
                         'format': 'mmmm d, yyyy',
                         'monthsFull': [u'January', u'February', u'March',
                                        u'April', u'May', u'June', u'July',
@@ -269,7 +268,6 @@ class DatetimeWidgetTests(unittest.TestCase):
                         'weekdaysFull': [u'Sunday', u'Monday', u'Tuesday',
                                          u'Wednesday', u'Thursday', u'Friday',
                                          u'Saturday'],
-                        'today': u'Today',
                         'selectYears': 200,
                         'placeholder': u'Enter date...',
                         'monthsShort': [u'Jan', u'Feb', u'Mar', u'Apr', u'May',
@@ -278,10 +276,11 @@ class DatetimeWidgetTests(unittest.TestCase):
                     },
                     'time': {
                         'placeholder': u'Enter time...',
-                        'today': u'Today',
                         'format': 'h:i a',
                         'interval': 15
-                    }
+                    },
+                    'today': u'Today',
+                    'clear': u'Clear',
                 }
             },
             self.widget._base_args(),

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -135,6 +135,9 @@ class DateWidget(BaseWidget, HTMLInputWidget):
                                           self.value) or u'').strip()
 
         args.setdefault('pattern_options', {})
+        if self.field.required:
+            # Required fields should not have a "Clear" button
+            args['pattern_options']['clear'] = False
         args['pattern_options'] = dict_merge(
             get_date_options(self.request),
             args['pattern_options'])


### PR DESCRIPTION
- Do not show the Clear button for required Date or DateTime fields.
- Test fixes for plone.app.widgets 2.1.