### PR TITLE
Add new class form-view-name-VIEWNAME to form element

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Bug fixes:
 - Catch TypeError occuring on conflicting subrequests in inline validation
   [tomgross]
 
+- Clean up: code-style, zca-decorators, replace lambda.
+  [jensens]
+
 
 2.2.1 (2017-02-12)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.2.2 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
 Breaking changes:
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add new class ``form-view-name-VIEWNAME`` to form element indicating the view name w/o old kss prefix.
+  New class's replaces ``++`` in view by ``__`` in order to produce valid class (CSS selectable) names.
+  [jensens]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,8 @@ Breaking changes:
 
 New features:
 
-- Add new class ``form-view-name-VIEWNAME`` to form element indicating the view name w/o old kss prefix.
-  New class's replaces ``++`` in view by ``__`` in order to produce valid class (CSS selectable) names.
+- Add new class ``view-name-VIEWNAME`` to form element indicating the view name w/o old kss prefix.
+  New class's replaces ``++`` in view by ``-`` in order to produce valid class (CSS selectable) names.
   [jensens]
 
 Bug fixes:

--- a/plone/app/z3cform/inline_validation.rst
+++ b/plone/app/z3cform/inline_validation.rst
@@ -52,10 +52,10 @@ Then we create a simple z3c form
 Let's verify that worked:
 
     >>> from zope.component import getMultiAdapter
-    >>> from zope.interface import Interface, implements
+    >>> from zope.interface import Interface, implementer
     >>> from Acquisition import Implicit
-    >>> class Bar(Implicit):
-    ...     implements(Interface)
+    >>> @implementer(Interface)
+    ... class Bar(Implicit):
     ...     def restrictedTraverse(self, name):
     ...         # fake traversal to the form
     ...         if name.startswith('@@'):

--- a/plone/app/z3cform/templates.py
+++ b/plone/app/z3cform/templates.py
@@ -21,6 +21,7 @@ def path(filepart):
 # Override the layout wrapper view default template with a more Plone-looking
 # one
 
+
 layout_factory = plone.z3cform.templates.ZopeTwoFormTemplateFactory(
     path('layout.pt'),
     form=plone.z3cform.interfaces.IFormWrapper,

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -61,10 +61,12 @@
                                   has_groups python:bool(groups);
                                   form_tabbing python:(has_groups and enable_form_tabbing) and 'enableFormTabbing pat-autotoc' or '';
                                   show_default_label python:has_groups and default_fieldset_label and len(view.widgets);
+                                  form_view_name_raw python:view.__name__ or request.getURL().split('/')[-1];
+                                  form_view_name python:'-'.join(['view', 'name'] + [x for x in form_view_name_raw.split('++') if x]);
                                   "
                       tal:attributes="action view/action|request/getURL;
                                       enctype view/enctype;
-                                      class python:'rowlike %s %s %s kssattr-formname-%s' % (unload_protection, form_tabbing, form_class, view.__name__ or request.getURL().split('/')[-1]);
+                                      class python:'rowlike {0} {1} {2} kssattr-formname-{3} {4}'.format(unload_protection, form_tabbing, form_class, form_view_name_raw, form_view_name);
                                       id view/id;
                                       method view/method|string:'post'
                                       ">

--- a/plone/app/z3cform/tests/example.py
+++ b/plone/app/z3cform/tests/example.py
@@ -6,13 +6,13 @@ from z3c.form import form
 from z3c.form import group
 from z3c.form.contentprovider import ContentProviders
 from z3c.form.interfaces import IFieldsAndContentProvidersForm
-from zope import interface
 from zope import schema
 from zope.contentprovider.provider import ContentProviderBase
-from zope.interface import implements
+from zope.interface import implementer
+from zope.interface import Interface
 
 
-class MySchema(interface.Interface):
+class MySchema(Interface):
     age = schema.Int(title=u'Age')
 
 
@@ -22,13 +22,13 @@ class MyContentProvider(ContentProviderBase):
         return 'My test content provider'
 
 
+@implementer(IFieldsAndContentProvidersForm)
 class MyForm(form.Form):
-    implements(IFieldsAndContentProvidersForm)
     contentProviders = ContentProviders()
     contentProviders['myContentProvider'] = MyContentProvider
     # defining a contentProvider position is mandatory...
     contentProviders['myContentProvider'].position = 0
-    label = u"Please enter your age"
+    label = u'Please enter your age'
     ignoreContext = True  # don't use context to get widget data
 
     @button.buttonAndHandler(u'Apply')
@@ -40,8 +40,8 @@ class MyFormWrapper(FormWrapper):
     form = MyForm
 
 
-class MyGroupSchema(interface.Interface):
-    name = schema.TextLine(title=u"name")
+class MyGroupSchema(Interface):
+    name = schema.TextLine(title=u'name')
 
 
 class MyGroup(group.Group):
@@ -52,7 +52,7 @@ class MyGroup(group.Group):
 
 class MyGroupForm(group.GroupForm, form.Form):
     fields = field.Fields(MySchema)
-    label = u"Please enter your age and Name"
+    label = u'Please enter your age and Name'
     ignoreContext = True  # don't use context to get widget data
 
     groups = [MyGroup, ]
@@ -66,15 +66,15 @@ class MyGroupFormWrapper(FormWrapper):
     form = MyGroupForm
 
 
-class MyMultiSchema(interface.Interface):
-    ages = schema.Dict(title=u"ages",
-                       key_type=schema.TextLine(title=u"name"),
-                       value_type=schema.Int(title=u"age", default=38))
+class MyMultiSchema(Interface):
+    ages = schema.Dict(title=u'ages',
+                       key_type=schema.TextLine(title=u'name'),
+                       value_type=schema.Int(title=u'age', default=38))
 
 
 class MyMultiForm(form.Form):
     fields = field.Fields(MyMultiSchema)
-    label = u"Please enter the names and ages for each person"
+    label = u'Please enter the names and ages for each person'
     ignoreContext = True  # don't use context to get widget data
 
     @button.buttonAndHandler(u'Apply')

--- a/plone/app/z3cform/tests/test_objectsubform.py
+++ b/plone/app/z3cform/tests/test_objectsubform.py
@@ -7,23 +7,24 @@ from plone.app.z3cform.utils import closest_content
 from z3c.form import field
 from z3c.form import form
 from z3c.form.object import registerFactoryAdapter
-from zope import interface
 from zope import publisher
 from zope import schema
 from zope.globalrequest import setRequest
+from zope.interface import implementer
+from zope.interface import Interface
 
 import unittest
 
 
-class ISubObject(interface.Interface):
+class ISubObject(Interface):
 
     title = schema.TextLine(
-        title=u"Subobject Title"
+        title=u'Subobject Title'
     )
 
 
+@implementer(ISubObject)
 class SubObject(object):
-    interface.implements(ISubObject)
 
     title = schema.fieldproperty.FieldProperty(ISubObject['title'])
 
@@ -34,19 +35,19 @@ class SubObject(object):
         return self.__name__ or ''
 
     def __repr__(self):
-        return "<SubObject title='{0:s}'>".format(self.title)
+        return '<SubObject title=\'{0:s}\'>'.format(self.title)
 
 
 registerFactoryAdapter(ISubObject, SubObject)
 
 
-class IComplexForm(interface.Interface):
+class IComplexForm(Interface):
 
     object_field = schema.List(
-        title=u"Object Field",
+        title=u'Object Field',
         required=False,
         value_type=schema.Object(
-            title=u"object",
+            title=u'object',
             schema=ISubObject
         )
     )
@@ -54,12 +55,13 @@ class IComplexForm(interface.Interface):
 
 class ComplexForm(form.Form):
     fields = field.Fields(IComplexForm)
-    label = u"Complex form"
+    label = u'Complex form'
     ignoreContext = True
 
 
+@implementer(IPloneFormLayer)
 class TestRequest(publisher.browser.TestRequest):
-    interface.implements(IPloneFormLayer)
+    pass
 
 
 class TestObjectSubForm(unittest.TestCase):

--- a/plone/app/z3cform/tests/test_utils.py
+++ b/plone/app/z3cform/tests/test_utils.py
@@ -18,7 +18,7 @@ class TestUnitCallCallables(unittest.TestCase):
     def test_simple_function(self):
         from plone.app.z3cform.utils import call_callables
 
-        test_in = lambda x: x
+        def test_in(x): return x
         test_compare = 'funny return value'
         test_out = call_callables(
             test_in,

--- a/plone/app/z3cform/tests/test_widget.py
+++ b/plone/app/z3cform/tests/test_widget.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 from plone.app.z3cform.interfaces import IPloneFormLayer
 from plone.app.z3cform.wysiwyg.widget import WysiwygWidget
-from zope import interface
 from zope import publisher
 from zope.globalrequest import setRequest
+from zope.interface import implementer
 
 import unittest
 
 
+@implementer(IPloneFormLayer)
 class TestRequest(publisher.browser.TestRequest):
-    interface.implements(IPloneFormLayer)
+    pass
 
 
 class TestForm(object):

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -17,7 +17,7 @@ from zope.component import provideUtility
 from zope.component.globalregistry import base
 from zope.globalrequest import setRequest
 from zope.interface import alsoProvides
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 from zope.publisher.browser import TestRequest as BaseTestRequest
 from zope.schema import BytesLine
@@ -37,8 +37,8 @@ import pytz
 import unittest
 
 
+@implementer(IVocabularyFactory)
 class ExampleVocabulary(object):
-    implements(IVocabularyFactory)
 
     def __call__(self, context, query=None):
         items = [u'One', u'Two', u'Three']
@@ -1204,7 +1204,7 @@ class RelatedItemsWidgetTests(unittest.TestCase):
             List(value_type=TextLine()),
             List(value_type=BytesLine()),
             List(value_type=Choice(values=['one', 'two', 'three']))
-            )
+        )
         for field in fields:
             expected_value_type = getattr(field.value_type, '_type', unicode)
             if expected_value_type is None:
@@ -1224,7 +1224,7 @@ class RelatedItemsWidgetTests(unittest.TestCase):
             self.assertEqual(
                 type(converter.toFieldValue('id1;id2')[0]),
                 expected_value_type
-                )
+            )
 
     def test_fieldwidget(self):
         from plone.app.z3cform.widget import RelatedItemsWidget
@@ -1270,7 +1270,7 @@ class RichTextWidgetTests(unittest.TestCase):
         self.request = self.layer['request']
 
         class IWithText(Interface):
-            text = RichTextField(title=u"Text")
+            text = RichTextField(title=u'Text')
 
         self.field = IWithText['text']
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 
-version = '2.2.2.dev0'
+version = '2.3.0.dev0'
 
 
 long_description = (


### PR DESCRIPTION
Add new class ``form-view-name-VIEWNAME`` to form element indicating the view name w/o old kss prefix. New class's replaces ``++`` in view by ``__`` in order to produce valid class (CSS selectable) names. Old class is still in place for bbb reasons, even if it has limited value.
