### PR TITLE
Fix broken get_tinymce_options when called with non-contentish contex…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,9 +14,13 @@ New features:
 
 Bug fixes:
 
+- Fix broken ``get_tinymce_options`` when called with non-contentish contexts like form or field contexts.
+  [thet]
+
 - Related Items Widget: In search mode, when no basePath was set, search site-wide.
   Fixes: https://github.com/plone/mockup/issues/769
   [thet]
+
 
 3.0 (2017-03-28)
 ----------------

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -598,7 +598,7 @@ class RichTextWidget(BaseWidget, patext_RichTextWidget):
         args.setdefault('pattern_options', {})
         merged_options = dict_merge(
             get_tinymce_options(
-                self.context,
+                self.wrapped_context(),
                 self.field,
                 self.request
             ),


### PR DESCRIPTION
…ts like form or field contexts.

Refs:
- https://github.com/plone/plone.app.widgets/pull/160
- https://github.com/plone/plone.app.widgets/issues/161

Fixes:
- https://github.com/collective/collective.easyform/issues/67

Merge all these:
- https://github.com/plone/plone.app.z3cform/pull/68
- https://github.com/plone/plone.app.widgets/pull/160
- https://github.com/plone/mockup/pull/771
- https://github.com/plone/Products.CMFPlone/pull/2064
