### PR TITLE
 WIP - PLIP 2150: date/time picker changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,11 @@ Bug fixes:
 New features:
 
 - Link widget: add ``placeholder`` attributes for external and email link input fields.
+- Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
+- PLIP 2150: Use ISO8601/HTML5 datetime-local format.
+  [thet]
+
+- PLIP 2150: Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Bug fixes:
 New features:
 
 - Link widget: add ``placeholder`` attributes for external and email link input fields.
+- PLIP 2150: Use ISO8601/HTML5 datetime-local format.
+  [thet]
+
 - Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
 - PLIP 2150: Use ISO8601/HTML5 datetime-local format.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 3.0.5 (unreleased)
 ------------------
+3.1 (unreleased)
+----------------
 
 Breaking changes:
 
@@ -47,9 +49,13 @@ New features:
   [thet]
 
 - PLIP 2150: Use ``pat-date-picker`` and ``pat-datetime-picker`` from Pattern library.
+- PLIP 2150 date widget improvements:
+  - Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
+  - Use ``pat-date-picker`` and ``pat-datetime-picker`` from Pattern library.
+  - Use ISO8601/HTML5 datetime-local format.
   [thet]
 
-- PLIP 2150: Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
+- Link widget: add ``placeholder`` attributes for external and email link input fields.
   [thet]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New features:
 - PLIP 2150: Use ISO8601/HTML5 datetime-local format.
   [thet]
 
+- PLIP 2150: Use ``pat-date-picker`` and ``pat-datetime-picker`` from Pattern library.
+  [thet]
+
 - PLIP 2150: Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
   [thet]
 

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -80,8 +80,8 @@ class DatetimeWidgetConverter(BaseDataConverter):
         """
         if value is self.field.missing_value:
             return u''
-        return ('{value.year:}-{value.month:02}-{value.day:02} '
-                '{value.hour:02}:{value.minute:02}').format(value=value)
+        return ('{value.year:}-{value.month:02}-{value.day:02}'
+                'T{value.hour:02}:{value.minute:02}').format(value=value)
 
     def toFieldValue(self, value):
         """Converts from widget value to field.
@@ -94,7 +94,7 @@ class DatetimeWidgetConverter(BaseDataConverter):
         """
         if not value:
             return self.field.missing_value
-        tmp = value.split(' ')
+        tmp = value.split('T')
         if not tmp[0]:
             return self.field.missing_value
         value = tmp[0].split('-')

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -38,7 +38,7 @@ class DateWidgetConverter(BaseDataConverter):
     """Data converter for date fields."""
 
     def toWidgetValue(self, value):
-        """Converts from field value to widget.
+        """Converts from field value to widget value.
 
         :param value: Field value.
         :type value: date
@@ -52,7 +52,7 @@ class DateWidgetConverter(BaseDataConverter):
                 ).format(value=value)
 
     def toFieldValue(self, value):
-        """Converts from widget value to field.
+        """Converts from widget value to field value.
 
         :param value: Value inserted by date widget.
         :type value: string
@@ -70,18 +70,21 @@ class DatetimeWidgetConverter(BaseDataConverter):
     """Data converter for datetime fields."""
 
     def toWidgetValue(self, value):
-        """Converts from field value to widget.
+        """Converts from field value to widget value.
 
         :param value: Field value.
         :type value: datetime
 
-        :returns: Datetime in format `Y-m-d H:M`
+        :returns: Datetime in format `Y-m-dTH:M`
         :rtype: string
         """
         if value is self.field.missing_value:
             return u''
-        return ('{value.year:}-{value.month:02}-{value.day:02}'
-                'T{value.hour:02}:{value.minute:02}').format(value=value)
+
+        ret = '{value.year:}-{value.month:02}-{value.day:02}'\
+            'T{value.hour:02}:{value.minute:02}'.format(value=value)
+
+        return ret
 
     def toFieldValue(self, value):
         """Converts from widget value to field.
@@ -94,24 +97,28 @@ class DatetimeWidgetConverter(BaseDataConverter):
         """
         if not value:
             return self.field.missing_value
+
         tmp = value.split('T')
         if not tmp[0]:
             return self.field.missing_value
-        value = tmp[0].split('-')
+
+        parts = tmp[0].split('-')
         if len(tmp) == 2 and ':' in tmp[1]:
-            value += tmp[1].split(':')
+            parts += tmp[1].split(':')
         else:
-            value += ['00', '00']
+            parts += ['00', '00']
+
+        ret = datetime(*map(int, parts))
 
         # TODO: respect the selected zone from the widget and just fall back
         # to default_zone
         default_zone = self.widget.default_timezone
         zone = default_zone(self.widget.context)\
             if safe_callable(default_zone) else default_zone
-        ret = datetime(*map(int, value))
         if zone:
             tzinfo = pytz.timezone(zone)
             ret = tzinfo.localize(ret)
+
         return ret
 
 

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -151,6 +151,7 @@ class DateWidget(BaseWidget, HTMLInputWidget):
         args['name'] = self.name
         args['value'] = (self.request.get(self.name,
                                           self.value) or u'').strip()
+        args['type'] = 'date'
 
         args.setdefault('pattern_options', {})
         if self.field.required:
@@ -224,6 +225,8 @@ class DatetimeWidget(DateWidget, HTMLInputWidget):
 
         if args['value'] and len(args['value'].split(' ')) == 1:
             args['value'] += ' 00:00'
+
+        args['type'] = 'datetime-local'
 
         args.setdefault('pattern_options', {})
         if 'time' in args['pattern_options']:

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -149,8 +149,8 @@ class DateWidget(BaseWidget, HTMLInputWidget):
         """
         args = super(DateWidget, self)._base_args()
         args['name'] = self.name
-        args['value'] = (self.request.get(self.name,
-                                          self.value) or u'').strip()
+        val = self.request.get(self.name, self.value) or u''
+        args['value'] = val.strip()
         args['type'] = 'date'
 
         args.setdefault('pattern_options', {})
@@ -159,7 +159,8 @@ class DateWidget(BaseWidget, HTMLInputWidget):
             args['pattern_options']['clear'] = False
         args['pattern_options'] = dict_merge(
             get_date_options(self.request),
-            args['pattern_options'])
+            args['pattern_options']
+        )
 
         return args
 
@@ -871,3 +872,4 @@ class SingleCheckBoxBoolWidget(SingleCheckBoxWidget):
 def SingleCheckBoxBoolFieldWidget(field, request):
     """IFieldWidget factory for CheckBoxWidget."""
     return FieldWidget(field, SingleCheckBoxBoolWidget(request))
+

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -223,10 +223,6 @@ class DatetimeWidget(DateWidget, HTMLInputWidget):
         :rtype: dict
         """
         args = super(DatetimeWidget, self)._base_args()
-
-        if args['value'] and len(args['value'].split(' ')) == 1:
-            args['value'] += ' 00:00'
-
         args['type'] = 'datetime-local'
 
         args.setdefault('pattern_options', {})

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -132,7 +132,7 @@ class DateWidget(BaseWidget, HTMLInputWidget):
     _converter = DateWidgetConverter
     _formater = 'date'
 
-    pattern = 'pickadate'
+    pattern = 'date-picker'
     pattern_options = BaseWidget.pattern_options.copy()
 
     def _base_args(self):
@@ -205,6 +205,7 @@ class DatetimeWidget(DateWidget, HTMLInputWidget):
     _converter = DatetimeWidgetConverter
     _formater = 'dateTime'
 
+    pattern = 'datetime-picker'
     pattern_options = DateWidget.pattern_options.copy()
 
     default_timezone = None

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 
-version = '3.0.5.dev0'
+version = '3.1.dev0'
 
 long_description = (
     read('README.rst') +


### PR DESCRIPTION
- Change the input type for date fields to ``date`` and for datetime fields to ``datetime-local``.
- Use ``pat-date-picker`` and ``pat-datetime-picker`` from Pattern library.
- Use ISO8601/HTML5 datetime-local format.
