### PR TITLE
Link widget data converter: return empty on empty input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,11 +10,14 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Link widget: add ``placeholder`` attributes for external and email link input fields.
+  [thet]
 
 Bug fixes:
 
-- *add item here*
+- Fix in link widget data converter for ``toWidgetValue`` to return an empty structure when the field value is empty instead of returning the portal root object.
+  Fixes: https://github.com/plone/Products.CMFPlone/issues/2163
+  [thet]
 
 
 3.0.2 (2017-09-06)
@@ -24,7 +27,7 @@ Bug fixes:
 
 - Test fixes for changes in plone.app.widgets querystring options.
   [thet]
-  
+
 
 3.0.1 (2017-07-03)
 ------------------

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -322,6 +322,8 @@ class LinkWidgetDataConverter(BaseDataConverter):
             'email': u'',
             'email_subject': u''
         }
+        if not value:
+            return result
         if value.startswith('mailto:'):
             # Handle mail URLs
             value = value[7:]   # strip mailto from beginning

--- a/plone/app/z3cform/templates/link_input.pt
+++ b/plone/app/z3cform/templates/link_input.pt
@@ -21,7 +21,7 @@
         <span class="linkLabel" i18n:translate="label_external_url">External</span>
         <div class="form-group main">
           <label for="external" i18n:translate="help_external_url">External URL (can be relative within this site or absolute if it starts with http:// or https://)</label>
-          <input type="text" name="external"
+          <input type="text" name="external" placeholder="https://domain.com"
                  tal:attributes="name string:${view/name}.external;
                                  value view/value/external | nothing" />
         </div>
@@ -32,7 +32,7 @@
         <div class="form-inline">
           <div class="form-group main">
             <label i18n:translate="help_email_url">Email Address</label>
-            <input type="text" name="email"
+            <input type="text" name="email" placeholder="name@domain.com"
                    tal:attributes="name string:${view/name}.email;
                                    value view/value/email | nothing" />
           </div>

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -1531,6 +1531,12 @@ class LinkWidgetIntegrationTests(unittest.TestCase):
         portal_url = self.portal.absolute_url()
         portal_path = '/'.join(self.portal.getPhysicalPath())
 
+        # Test empty value
+        widget_value = converter.toWidgetValue(u'')
+        self.assertEqual(widget_value['internal'], u'')
+        self.assertEqual(widget_value['external'], u'')
+        self.assertEqual(widget_value['email'], u'')
+
         # Test external URLs
         self.assertEqual(
             converter.toWidgetValue(u'https://plone.org')['external'],


### PR DESCRIPTION
Fix in link widget data converter for ``toWidgetValue`` to return an empty structure when the field value is empty instead of returning the portal root object.
Fixes: https://github.com/plone/Products.CMFPlone/issues/2163

Also: add placeholders for email and external link.

Merge together:
https://github.com/plone/plone.app.contenttypes/pull/431
https://github.com/plone/plone.app.z3cform/pull/76