### PR TITLE
Fix SingleCheckBoxBoolWidget description to render structure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix SingleCheckBoxBoolWidget description to render structure
+  [allusa]
 
 
 3.0.4 (2018-02-04)

--- a/plone/app/z3cform/templates/singlecheckboxbool_input.pt
+++ b/plone/app/z3cform/templates/singlecheckboxbool_input.pt
@@ -77,7 +77,7 @@
           title="Required"
           tal:condition="item/required"
           i18n:attributes="title title_required;">&nbsp;</span>
-    <span class="formHelp" tal:content="item/description">Description</span>
+    <span class="formHelp" tal:content="structure item/description">Description</span>
   </label>
  </span>
 </span>


### PR DESCRIPTION
The description could be an HTML snippet, so *structure* is needed as appeared in the deprecated 
 singlecheckbox.pt