### PR TITLE
Change the RichTextWidget to use unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Bug fixes:
   [allusa]
 
 - Prepare for Python 2 / 3 compatibility
-  [pbauer]
+  [pbauer, MatthewWilkes]
 
 
 3.0.4 (2018-02-04)

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -609,10 +609,8 @@ class RichTextWidget(BaseWidget, patext_RichTextWidget):
     def _base_args(self):
         args = super(RichTextWidget, self)._base_args()
         args['name'] = self.name
-        value = self.value and self.value.raw_encoded or ''
-        value = (self.request.get(self.field.getName(), value))
-        if six.PY2:
-            value = value.decode('utf-8')
+        value = self.value and self.value.raw or u''
+        value = self.request.get(self.name, value)
         args['value'] = value
 
         args.setdefault('pattern_options', {})


### PR DESCRIPTION
This fixes rendering errors when instantiating the pattern under
Python3 as lxml expects unicode or ASCII.