### PR TITLE
Fix RichTextWidget with TinyMCE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ Bug fixes:
 - Prepare for Python 2 / 3 compatibility
   [pbauer, MatthewWilkes]
 
+- Render mimetype selection box correctly for a ``RichTextWidget`` which also
+  brings back the TinyMCE.
+  [sallner]
+
 
 3.0.4 (2018-02-04)
 ------------------

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -693,7 +693,7 @@ class RichTextWidget(BaseWidget, patext_RichTextWidget):
                 # Render the combined widget
                 rendered = '{0}\n{1}'.format(
                     textarea_widget.render(),
-                    etree.tostring(mt_select),
+                    etree.tostring(mt_select, encoding='unicode'),
                 )
             return rendered
 


### PR DESCRIPTION
Finally faulty rendering of the mimetype selector shadowed the specific configuration of the TinyMCE. 
This resulted in `b' text/html'` in the `@@edit`.  