### PR TITLE
a11y: added role attribute for portalMessage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- a11y: added role attribute for portalMessage
+  [nzambello]
 
 
 3.0.8 (2018-11-29)

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -16,13 +16,13 @@
 
                 <tal:status define="status view/status;
                                     has_error python:view.widgets.errors or status == getattr(view, 'formErrorsMessage', None)" condition="status">
-                    <dl class="portalMessage error" tal:condition="has_error">
+                    <dl class="portalMessage error" tal:condition="has_error" role="alert">
                         <dt i18n:translate="">
                             Error
                         </dt>
                         <dd tal:content="status" />
                     </dl>
-                    <dl class="portalMessage info" tal:condition="not:has_error">
+                    <dl class="portalMessage info" tal:condition="not:has_error" role="status">
                         <dt i18n:translate="">
                             Info
                         </dt>


### PR DESCRIPTION
Screen readers could now see and read correctly alerts/status messages.