### PR TITLE
Fix value conversion in AjaxSelectWidget to respect tokens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ Bug fixes:
 
 - LinkFieldWidget: added converter method toFieldValue [ksuess]
 
+- Fixes AjaxSelectWidget to respect tokens different from values in vocabularies.
+  This includes changes in both, the converter and the widget itself.
+  A test was added too.
+  ``get_ajaxselect_options`` from ``plone.app.widgets.utils`` is assimilated by the widget now too simplify the whole code,
+  so the one in the other package is dead code now and will be deprecated there.
+  [jensens]
+
 
 3.0.9 (2019-01-08)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 - Add display template for AjaxSelectWidget showing the actual vocabularies term title.
   [jensens]
 
+- ``IFieldPermissionChecker`` was moved here from plone.app.widgets.
+  [jensens]
+
 Bug fixes:
 
 - Fixes AjaxSelectWidget to respect tokens different from values in vocabularies.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-3.0.10 (unreleased)
--------------------
+3.1.0 (unreleased)
+------------------
 
 Breaking changes:
 
@@ -10,18 +10,16 @@ Breaking changes:
 
 New features:
 
-- *add item here*
-
-Bug fixes:
-
-- LinkFieldWidget: added converter method toFieldValue [ksuess]
-
 - Fixes AjaxSelectWidget to respect tokens different from values in vocabularies.
   This includes changes in both, the converter and the widget itself.
   A test was added too.
   ``get_ajaxselect_options`` from ``plone.app.widgets.utils`` is assimilated by the widget now too simplify the whole code,
   so the one in the other package is dead code now and will be deprecated there.
   [jensens]
+
+Bug fixes:
+
+- LinkFieldWidget: added converter method toFieldValue [ksuess]
 
 
 3.0.9 (2019-01-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,14 +10,17 @@ Breaking changes:
 
 New features:
 
+- Add display template for AjaxSelectWidget showing the actual vocabularies term title.
+  [jensens]
+
+Bug fixes:
+
 - Fixes AjaxSelectWidget to respect tokens different from values in vocabularies.
   This includes changes in both, the converter and the widget itself.
   A test was added too.
   ``get_ajaxselect_options`` from ``plone.app.widgets.utils`` is assimilated by the widget now too simplify the whole code,
   so the one in the other package is dead code now and will be deprecated there.
   [jensens]
-
-Bug fixes:
 
 - LinkFieldWidget: added converter method toFieldValue [ksuess]
 

--- a/plone/app/z3cform/configure.zcml
+++ b/plone/app/z3cform/configure.zcml
@@ -221,4 +221,10 @@
            for="z3c.form.interfaces.ITextWidget
                 plone.app.z3cform.interfaces.IPloneFormLayer"/>
 
+  <utility
+    name="ZPublisher.HTTPRequest.FileUpload"
+    provides="plone.namedfile.interfaces.IStorage"
+    factory=".factories.Zope2FileUploadStorable"
+  />
+
 </configure>

--- a/plone/app/z3cform/configure.zcml
+++ b/plone/app/z3cform/configure.zcml
@@ -115,6 +115,13 @@
       template="templates/singlecheckboxbool_input.pt"
       />
   <z3c:widgetTemplate
+      mode="display"
+      field="*"
+      widget=".interfaces.IAjaxSelectWidget"
+      layer=".interfaces.IPloneFormLayer"
+      template="templates/ajaxselect_display.pt"
+      />
+  <z3c:widgetTemplate
       mode="hidden"
       field="zope.schema.interfaces.IBool"
       widget=".interfaces.ISingleCheckBoxBoolWidget"

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -142,7 +142,7 @@ class SelectWidgetConverterBase(object):
 @adapter(IField, ISelectWidget)
 class SequenceSelectWidgetConverter(
         SelectWidgetConverterBase,
-        SequenceDataConverter
+        SequenceDataConverter,
 ):
     """Data converter for IField fields using the SelectWidget.
     """
@@ -151,7 +151,7 @@ class SequenceSelectWidgetConverter(
 @adapter(ICollection, ISelectWidget)
 class SelectWidgetConverter(
     SelectWidgetConverterBase,
-    CollectionSequenceDataConverter
+    CollectionSequenceDataConverter,
 ):
     """Data converter for ICollection fields using the SelectWidget.
     """

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -141,14 +141,20 @@ class SelectWidgetConverterBase(object):
 
 @adapter(IField, ISelectWidget)
 class SequenceSelectWidgetConverter(
-        SelectWidgetConverterBase, SequenceDataConverter):
-    pass
+        SelectWidgetConverterBase,
+        SequenceDataConverter
+):
+    """Data converter for IField fields using the SelectWidget.
+    """
 
 
 @adapter(ICollection, ISelectWidget)
 class SelectWidgetConverter(
-        SelectWidgetConverterBase, CollectionSequenceDataConverter):
-    pass
+    SelectWidgetConverterBase,
+    CollectionSequenceDataConverter
+):
+    """Data converter for ICollection fields using the SelectWidget.
+    """
 
 
 @adapter(ICollection, IAjaxSelectWidget)
@@ -157,7 +163,7 @@ class AjaxSelectWidgetConverter(BaseDataConverter):
     """
 
     def toWidgetValue(self, value):
-        """Converts from field value to widget.
+        """Converts from field value to widget tokenized widget value.
 
         :param value: Field value.
         :type value: list |tuple | set
@@ -167,8 +173,18 @@ class AjaxSelectWidgetConverter(BaseDataConverter):
         """
         if not value:
             return self.field.missing_value
-        separator = getattr(self.widget, 'separator', ';')
-        return separator.join(six.text_type(v) for v in value)
+        vocabulary = self.widget.get_vocabulary()
+        tokenized_value = []
+        for term_value in value:
+            if vocabulary is not None:
+                try:
+                    term = vocabulary.getTerm(term_value)
+                    tokenized_value.append(term.token)
+                    continue
+                except LookupError:
+                    pass
+            tokenized_value.append(six.text_type(term_value))
+        return getattr(self.widget, 'separator', ';').join(tokenized_value)
 
     def toFieldValue(self, value):
         """Converts from widget value to field.
@@ -188,8 +204,22 @@ class AjaxSelectWidgetConverter(BaseDataConverter):
         if isinstance(valueType, tuple):
             valueType = valueType[0]
         separator = getattr(self.widget, 'separator', ';')
-        return collectionType(valueType and valueType(v) or v
-                              for v in value.split(separator))
+        self.widget.update()  # needed to have a vocabulary
+        vocabulary = self.widget.get_vocabulary()
+        untokenized_value = []
+        for token in value.split(separator):
+            if vocabulary is not None:
+                try:
+                    term = vocabulary.getTermByToken(token)
+                    untokenized_value.append(term.value)
+                    continue
+                except LookupError:
+                    pass
+            untokenized_value.append(
+                valueType(token) if valueType else token
+            )
+
+        return collectionType(untokenized_value)
 
 
 @adapter(IRelationChoice, IRelatedItemsWidget)

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -216,7 +216,7 @@ class AjaxSelectWidgetConverter(BaseDataConverter):
                 except LookupError:
                     pass
             untokenized_value.append(
-                valueType(token) if valueType else token
+                valueType(token) if valueType else token,
             )
 
         return collectionType(untokenized_value)

--- a/plone/app/z3cform/factories.py
+++ b/plone/app/z3cform/factories.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from zope.interface import implementer
+from plone.namedfile.storages import MAXCHUNKSIZE
+from plone.namedfile.interfaces import IStorage
+
+
+@implementer(IStorage)
+class Zope2FileUploadStorable(object):
+
+    def store(self, data, blob):
+        data.seek(0)
+        with blob.open('w') as fp:
+            block = data.read(MAXCHUNKSIZE)
+            while block:
+                fp.write(block)
+                block = data.read(MAXCHUNKSIZE)

--- a/plone/app/z3cform/interfaces.py
+++ b/plone/app/z3cform/interfaces.py
@@ -4,12 +4,26 @@ from z3c.form.interfaces import IFormLayer
 from z3c.form.interfaces import ISelectWidget as IBaseSelectWidget
 from z3c.form.interfaces import ISingleCheckBoxWidget
 from z3c.form.interfaces import ITextWidget
+from zope.interface import Interface
 from zope.schema.interfaces import IDate
 from zope.schema.interfaces import IDatetime
 
 
 class IPloneFormLayer(IFormLayer):
     """Request layer installed via browserlayer.xml"""
+
+
+class IFieldPermissionChecker(Interface):
+    """Adapter factory for checking whether a user has permission to
+    edit a specific field on a content object.
+    """
+
+    def validate(field_name, vocabulary_name=None):
+        """Returns True if the current user has permission to edit the
+        `field_name` field.  Returns False if the user does not have
+        permission.  Raises and AttributeError if the field cannot be
+        found.
+        """
 
 
 class IDateField(IDate):

--- a/plone/app/z3cform/interfaces.py
+++ b/plone/app/z3cform/interfaces.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from plone.app.textfield.widget import IRichTextWidget as patextfield_IRichTextWidget  # noqa
-from z3c.form.interfaces import ISelectWidget as IBaseSelectWidget
 from z3c.form.interfaces import IFormLayer
+from z3c.form.interfaces import ISelectWidget as IBaseSelectWidget
 from z3c.form.interfaces import ISingleCheckBoxWidget
 from z3c.form.interfaces import ITextWidget
 from zope.schema.interfaces import IDate

--- a/plone/app/z3cform/templates/ajaxselect_display.pt
+++ b/plone/app/z3cform/templates/ajaxselect_display.pt
@@ -1,0 +1,26 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+    <span id="" class=""
+          tal:attributes="id view/id;
+                          class view/klass;
+                          style view/style;
+                          title view/title;
+                          lang view/lang;
+                          onclick view/onclick;
+                          ondblclick view/ondblclick;
+                          onmousedown view/onmousedown;
+                          onmouseup view/onmouseup;
+                          onmouseover view/onmouseover;
+                          onmousemove view/onmousemove;
+                          onmouseout view/onmouseout;
+                          onkeypress view/onkeypress;
+                          onkeydown view/onkeydown;
+                          onkeyup view/onkeyup"><tal:block
+          condition="view/value"
+    />
+      <tal:loop tal:repeat="item python:view.display_items()">
+        <span data-token="${python:item['token']}">${python:item['title']}</span><tal:if tal:condition="python: not repeat.item.end" tal:replace="python:view.separator" />
+      </tal:loop>
+    </span>
+</html>

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -2,8 +2,8 @@
 from datetime import date
 from datetime import datetime
 from json import loads
-from mock import Mock
 from lxml import html
+from mock import Mock
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.widgets.utils import NotImplemented as PatternNotImplemented
@@ -57,12 +57,12 @@ def example_vocabulary_factory(context, query=None):
         [
             SimpleTerm(
                 item.lower(),  # value
-                token="token_{0}".format(item.lower()),
-                title=item
+                token='token_{0}'.format(item.lower()),
+                title=item,
             )
             for item in items
             if query is None or query.lower() in item.lower()
-        ]
+        ],
     )
     tmp.test = 1
     return tmp
@@ -157,7 +157,7 @@ class BaseWidgetTests(unittest.TestCase):
         observed_attrib = html.fromstring(output).attrib
         self.assertEqual(
             sorted(observed_attrib),
-            ['class', 'data-pat-example', 'type']
+            ['class', 'data-pat-example', 'type'],
         )
         self.assertEqual(observed_attrib['class'], 'pat-example')
         self.assertEqual(observed_attrib['type'], 'text')
@@ -167,8 +167,8 @@ class BaseWidgetTests(unittest.TestCase):
                 'subdict': {
                     'subsubnormal': 789,
                     'subsublist': [7, 8, 9, 'testcontext'],
-                    'subsubtuple': [7, 8, 9, 'testcontext']
-                }
+                    'subsubtuple': [7, 8, 9, 'testcontext'],
+                },
             },
         )
 
@@ -843,7 +843,10 @@ class AjaxSelectWidgetTests(unittest.TestCase):
                 'pattern': 'select2',
                 'pattern_options': {
                     'vocabularyUrl': '/@@getVocabulary?name=example',
-                    'initialValues': {'token_three': u'Three', 'token_two': u'Two'},
+                    'initialValues': {
+                        'token_three': u'Three',
+                        'token_two': u'Two',
+                    },
                     'separator': ';',
                 },
             },
@@ -986,7 +989,7 @@ class AjaxSelectWidgetTests(unittest.TestCase):
         field = Tuple(
             __name__='listfield',
             value_type=Choice(
-                vocabulary="example"
+                vocabulary='example',
             ),
         )
         widget = AjaxSelectWidget(self.request)

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -1118,10 +1118,6 @@ class QueryStringWidgetTests(unittest.TestCase):
         self.assertEqual(converter.toFieldValue(u'[]'), None)
 
     @mock.patch(
-        'plone.app.widgets.utils.get_ajaxselect_options',
-        new=lambda *args, **kwargs: None,
-    )
-    @mock.patch(
         'plone.app.widgets.utils.get_date_options',
         new=lambda *args, **kwargs: None,
     )
@@ -1141,7 +1137,7 @@ class QueryStringWidgetTests(unittest.TestCase):
                     'indexOptionsUrl': '/@@qsOptions',
                     'previewCountURL': '/@@querybuildernumberofresults',
                     'previewURL': '/@@querybuilder_html_results',
-                    'patternAjaxSelectOptions': None,
+                    'patternAjaxSelectOptions': {'separator': ';'},
                     'patternDateOptions': None,
                     'patternRelateditemsOptions': None,
                 },

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -27,9 +27,9 @@ from zope.component import provideUtility
 from zope.component.globalregistry import base
 from zope.globalrequest import setRequest
 from zope.interface import alsoProvides
-from zope.interface import implementer
 from zope.interface import Interface
-from zope.publisher.browser import TestRequest as BaseTestRequest
+from zope.interface import provider
+from zope.publisher.browser import TestRequest
 from zope.schema import BytesLine
 from zope.schema import Choice
 from zope.schema import Date
@@ -50,22 +50,22 @@ import six
 import unittest
 
 
-@implementer(IVocabularyFactory)
-class ExampleVocabulary(object):
-
-    def __call__(self, context, query=None):
-        items = [u'One', u'Two', u'Three']
-        tmp = SimpleVocabulary([
-            SimpleTerm(it.lower(), it.lower(), it)
-            for it in items
-            if query is None or query.lower() in it.lower()
-        ])
-        tmp.test = 1
-        return tmp
-
-
-class TestRequest(BaseTestRequest):
-    pass
+@provider(IVocabularyFactory)
+def example_vocabulary_factory(context, query=None):
+    items = [u'One', u'Two', u'Three']
+    tmp = SimpleVocabulary(
+        [
+            SimpleTerm(
+                item.lower(),  # value
+                token="token_{0}".format(item.lower()),
+                title=item
+            )
+            for item in items
+            if query is None or query.lower() in item.lower()
+        ]
+    )
+    tmp.test = 1
+    return tmp
 
 
 class BaseWidgetTests(unittest.TestCase):
@@ -805,7 +805,7 @@ class AjaxSelectWidgetTests(unittest.TestCase):
 
     def setUp(self):
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
-        provideUtility(ExampleVocabulary(), name=u'example')
+        provideUtility(example_vocabulary_factory, name=u'example')
 
     def test_widget(self):
         from plone.app.z3cform.widget import AjaxSelectWidget
@@ -835,19 +835,19 @@ class AjaxSelectWidgetTests(unittest.TestCase):
             },
         )
 
-        widget.value = 'three;two'
-        self.assertEqual(
-            widget._base_args(),
+        widget.value = 'token_three;token_two'
+        self.assertDictEqual(
             {
                 'name': None,
-                'value': 'three;two',
+                'value': 'token_three;token_two',
                 'pattern': 'select2',
                 'pattern_options': {
                     'vocabularyUrl': '/@@getVocabulary?name=example',
-                    'initialValues': {'three': u'Three', 'two': u'Two'},
+                    'initialValues': {'token_three': u'Three', 'token_two': u'Two'},
                     'separator': ';',
                 },
             },
+            widget._base_args(),
         )
 
     def test_widget_list_orderable(self):
@@ -967,6 +967,40 @@ class AjaxSelectWidgetTests(unittest.TestCase):
         self.assertEqual(
             converter.toFieldValue('123;456;789'),
             ['123', '456', '789'],
+        )
+
+        self.assertEqual(
+            converter.toWidgetValue([]),
+            None,
+        )
+
+        self.assertEqual(
+            converter.toWidgetValue(['123', '456', '789']),
+            '123;456;789',
+        )
+
+    def test_data_converter_collection_with_vocabulary(self):
+        from plone.app.z3cform.widget import AjaxSelectWidget
+        from plone.app.z3cform.converters import AjaxSelectWidgetConverter
+
+        field = Tuple(
+            __name__='listfield',
+            value_type=Choice(
+                vocabulary="example"
+            ),
+        )
+        widget = AjaxSelectWidget(self.request)
+        widget.field = field
+        converter = AjaxSelectWidgetConverter(field, widget)
+
+        self.assertEqual(
+            converter.toFieldValue(''),
+            field.missing_value,
+        )
+
+        self.assertEqual(
+            converter.toFieldValue('token_one;token_two;token_three'),
+            ('one', 'two', 'three'),
         )
 
         self.assertEqual(

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -393,7 +393,7 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
         if self.vocabulary:
             factory = queryUtility(
                 IVocabularyFactory,
-                self.vocabulary
+                self.vocabulary,
             )
             if factory:
                 return factory(self._view_context())
@@ -406,7 +406,7 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
             options['vocabularyUrl'] = '{0}/{1}?name={2}'.format(
                 get_context_url(self._view_context()),
                 self.vocabulary_view,
-                self.vocabulary
+                self.vocabulary,
             )
             field_name = self.field and self.field.__name__ or None
             if field_name:
@@ -483,7 +483,7 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
                 'plone.roles_allowed_to_add_keywords', set())
             roles = set(user.getRolesInContext(context))
             allowNewItems = bool(
-                roles.intersection(roles_allowed_to_add_keywords)
+                roles.intersection(roles_allowed_to_add_keywords),
             )
             args['pattern_options']['allowNewItems'] = allowNewItems
 

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -398,6 +398,22 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
             if factory:
                 return factory(self._view_context())
 
+    def display_items(self):
+        if self.value:
+            tokens = self.value.split(self.separator)
+            vocabulary = self.get_vocabulary()
+            for token in tokens:
+                item = {'token': token, 'title': token}
+                if vocabulary is not None:
+                    try:
+                        item['title'] = vocabulary.getTermByToken(token).title
+                    except LookupError:
+                        pass
+                yield item
+
+    def has_multiple_values(self):
+        return self.value and self.value.split(self.separator)
+
     def _ajaxselect_options(self):
         options = {
             'separator': self.separator,

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -3,6 +3,7 @@ from Acquisition import aq_base
 from Acquisition import ImplicitAcquisitionWrapper
 from lxml import etree
 from OFS.interfaces import ISimpleItem
+from plone.app.event.base import first_weekday
 from plone.app.textfield.value import RichTextValue
 from plone.app.textfield.widget import RichTextWidget as patext_RichTextWidget
 from plone.app.vocabularies.terms import TermWithDescription
@@ -10,7 +11,6 @@ from plone.app.widgets.base import dict_merge
 from plone.app.widgets.base import InputWidget
 from plone.app.widgets.base import SelectWidget as BaseSelectWidget
 from plone.app.widgets.base import TextareaWidget
-from plone.app.widgets.utils import first_weekday
 from plone.app.widgets.utils import get_context_url
 from plone.app.widgets.utils import get_date_options
 from plone.app.widgets.utils import get_datetime_options

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -68,8 +68,8 @@ from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
-import json
 import collections
+import json
 import six
 
 

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
 from Acquisition import ImplicitAcquisitionWrapper
-from OFS.interfaces import ISimpleItem
 from lxml import etree
+from OFS.interfaces import ISimpleItem
 from plone.app.textfield.value import RichTextValue
 from plone.app.textfield.widget import RichTextWidget as patext_RichTextWidget
 from plone.app.vocabularies.terms import TermWithDescription
-from plone.app.widgets.base import SelectWidget as BaseSelectWidget
 from plone.app.widgets.base import dict_merge
 from plone.app.widgets.base import InputWidget
+from plone.app.widgets.base import SelectWidget as BaseSelectWidget
 from plone.app.widgets.base import TextareaWidget
-from plone.app.widgets.utils import NotImplemented as PatternNotImplemented
 from plone.app.widgets.utils import first_weekday
 from plone.app.widgets.utils import get_context_url
 from plone.app.widgets.utils import get_date_options
@@ -19,6 +18,7 @@ from plone.app.widgets.utils import get_querystring_options
 from plone.app.widgets.utils import get_relateditems_options
 from plone.app.widgets.utils import get_tinymce_options
 from plone.app.widgets.utils import get_widget_form
+from plone.app.widgets.utils import NotImplemented as PatternNotImplemented
 from plone.app.z3cform.converters import DatetimeWidgetConverter
 from plone.app.z3cform.converters import DateWidgetConverter
 from plone.app.z3cform.interfaces import IAjaxSelectWidget

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -12,7 +12,7 @@ from plone.app.widgets.base import InputWidget
 from plone.app.widgets.base import TextareaWidget
 from plone.app.widgets.utils import NotImplemented as PatternNotImplemented
 from plone.app.widgets.utils import first_weekday
-from plone.app.widgets.utils import get_ajaxselect_options
+from plone.app.widgets.utils import get_context_url
 from plone.app.widgets.utils import get_date_options
 from plone.app.widgets.utils import get_datetime_options
 from plone.app.widgets.utils import get_querystring_options
@@ -38,11 +38,11 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IEditingSchema
 from Products.CMFPlone.utils import safe_unicode
 from six.moves import UserDict
+from z3c.form import interfaces as form_ifaces
 from z3c.form.browser.checkbox import SingleCheckBoxWidget
 from z3c.form.browser.select import SelectWidget as z3cform_SelectWidget
 from z3c.form.browser.text import TextWidget as z3cform_TextWidget
 from z3c.form.browser.widget import HTMLInputWidget
-from z3c.form import interfaces as form_ifaces
 from z3c.form.interfaces import IEditForm
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import IForm
@@ -54,6 +54,7 @@ from z3c.form.widget import Widget
 from zope.component import adapter
 from zope.component import ComponentLookupError
 from zope.component import getUtility
+from zope.component import queryUtility
 from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implementer
@@ -63,6 +64,7 @@ from zope.schema.interfaces import IBool
 from zope.schema.interfaces import IChoice
 from zope.schema.interfaces import ICollection
 from zope.schema.interfaces import ISequence
+from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
@@ -372,11 +374,59 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
     vocabulary_view = '@@getVocabulary'
     orderable = False
 
+    def _view_context(self):
+        view_context = get_widget_form(self)
+        # For EditForms and non-Forms (in tests), the vocabulary is looked
+        # up on the context, otherwise on the view
+        if IEditForm.providedBy(view_context):
+            if self.is_subform_widget():
+                view_context = self.form.parentForm.context
+            elif not ISimpleItem.providedBy(self.context):
+                view_context = self.form.context
+            else:
+                view_context = self.context
+        elif not IForm.providedBy(view_context):
+            view_context = self.context
+        return view_context
+
+    def get_vocabulary(self):
+        if self.vocabulary:
+            factory = queryUtility(
+                IVocabularyFactory,
+                self.vocabulary
+            )
+            if factory:
+                return factory(self._view_context())
+
+    def _ajaxselect_options(self):
+        options = {
+            'separator': self.separator,
+        }
+        if self.vocabulary:
+            options['vocabularyUrl'] = '{0}/{1}?name={2}'.format(
+                get_context_url(self._view_context()),
+                self.vocabulary_view,
+                self.vocabulary
+            )
+            field_name = self.field and self.field.__name__ or None
+            if field_name:
+                options['vocabularyUrl'] += '&field={0}'.format(field_name)
+            vocabulary = self.get_vocabulary()
+            if vocabulary and self.value:
+                options['initialValues'] = dict()
+                for token in self.value.split(self.separator):
+                    try:
+                        term = vocabulary.getTermByToken(token)
+                        options['initialValues'][term.token] = term.title
+                    except LookupError:
+                        options['initialValues'][token] = token
+
+        return options
+
     def update(self):
         super(AjaxSelectWidget, self).update()
         field = getattr(self, 'field', None)
-        if ICollection.providedBy(self.field):
-            field = self.field.value_type
+        field = getattr(field, 'value_type', field)
         if (not self.vocabulary and field is not None and
                 getattr(field, 'vocabularyName', None)):
             self.vocabulary = field.vocabularyName
@@ -393,28 +443,13 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
         :returns: Arguments which will be passed to _base
         :rtype: dict
         """
-
         args = super(AjaxSelectWidget, self)._base_args()
-
         args['name'] = self.name
         args['value'] = self.value
-
         args.setdefault('pattern_options', {})
-
-        field_name = self.field and self.field.__name__ or None
-
         context = self.context
-        view_context = get_widget_form(self)
-        # For EditForms and non-Forms (in tests), the vocabulary is looked
-        # up on the context, otherwise on the view
-        if (
-            IEditForm.providedBy(view_context) or
-            not IForm.providedBy(view_context)
-        ):
-            view_context = context
-
-        vocabulary_name = self.vocabulary
         field = None
+
         if IChoice.providedBy(self.field):
             args['pattern_options']['maximumSelectionSize'] = 1
             field = self.field
@@ -424,9 +459,7 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
             args['pattern_options']['allowNewItems'] = 'false'
 
         args['pattern_options'] = dict_merge(
-            get_ajaxselect_options(view_context, args['value'], self.separator,
-                                   vocabulary_name, self.vocabulary_view,
-                                   field_name),
+            self._ajaxselect_options(),
             args['pattern_options'])
 
         if field and getattr(field, 'vocabulary', None):
@@ -447,12 +480,11 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
 
             registry = getUtility(IRegistry)
             roles_allowed_to_add_keywords = registry.get(
-                'plone.roles_allowed_to_add_keywords', [])
+                'plone.roles_allowed_to_add_keywords', set())
             roles = set(user.getRolesInContext(context))
-
-            allowNewItems = 'false'
-            if roles.intersection(roles_allowed_to_add_keywords):
-                allowNewItems = 'true'
+            allowNewItems = bool(
+                roles.intersection(roles_allowed_to_add_keywords)
+            )
             args['pattern_options']['allowNewItems'] = allowNewItems
 
         return args

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -485,7 +485,9 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
             allowNewItems = bool(
                 roles.intersection(roles_allowed_to_add_keywords),
             )
-            args['pattern_options']['allowNewItems'] = allowNewItems
+            args['pattern_options']['allowNewItems'] = str(
+                allowNewItems,
+            ).lower()
 
         return args
 

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -412,7 +412,7 @@ class AjaxSelectWidget(BaseWidget, z3cform_TextWidget):
             if field_name:
                 options['vocabularyUrl'] += '&field={0}'.format(field_name)
             vocabulary = self.get_vocabulary()
-            if vocabulary and self.value:
+            if vocabulary is not None and self.value:
                 options['initialValues'] = dict()
                 for token in self.value.split(self.separator):
                     try:

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,11 @@ setup(
     long_description=long_description,
     classifiers=[
         "Framework :: Plone",
+        "Framework :: Plone :: Core",
         "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
         "Framework :: Zope2",
+        "Framework :: Zope :: 2",
         "Framework :: Zope :: 4",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python",
@@ -49,14 +51,14 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'setuptools',
         'Acquisition',
-        'Products.CMFCore',
-        'Products.CMFPlone',
-        'Zope2',  # Products.Five
-        'plone.app.widgets>=2.0.0.dev0',
+        'plone.app.textfield',
+        'plone.app.widgets>=2.4.2.dev0',
         'plone.protect',
         'plone.z3cform>=0.5.11dev',
+        'Products.CMFCore',
+        'Products.CMFPlone',
+        'setuptools',
         'six',
         'z3c.form >= 3.0',
         'z3c.formwidget.query',
@@ -69,7 +71,7 @@ setup(
         'zope.interface',
         'zope.schema',
         'zope.traversing',
-        'plone.app.textfield'
+        'Zope2',
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 
-version = '3.0.10.dev0'
+version = '3.1.0.dev0'
 
 long_description = (
     read('README.rst') +
@@ -30,10 +30,7 @@ setup(
     classifiers=[
         "Framework :: Plone",
         "Framework :: Plone :: Core",
-        "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
-        "Framework :: Zope2",
-        "Framework :: Zope :: 2",
         "Framework :: Zope :: 4",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python",


### PR DESCRIPTION
all started in see https://github.com/plone/plone.app.vocabularies/pull/56#issuecomment-476598570

Fixes AjaxSelectWidget to respect tokens different from values in vocabularies.

This includes changes in both, the converter and the widget itself. 

A test was added too.

``get_ajaxselect_options`` from ``plone.app.widgets.utils`` is assimilated by the widget now too simplify the whole code,  so the one in the other package is dead code now and will be deprecated there.
