### PR TITLE
Fix wrong default for method attribute in pt

### DIFF
--- a/news/107.bugfix
+++ b/news/107.bugfix
@@ -1,0 +1,2 @@
+- Fix wrong default for method attribute in pt
+  [mamico]

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -68,8 +68,7 @@
                                       enctype view/enctype;
                                       class python:'rowlike {0} {1} {2} kssattr-formname-{3} {4}'.format(unload_protection, form_tabbing, form_class, form_view_name_raw, form_view_name);
                                       id view/id;
-                                      method view/method|string:'post'
-                                      ">
+                                      method view/method|string:post">
 
                     <metal:block define-slot="formtop" />
 


### PR DESCRIPTION
if `view/method`  raises attributeerror the html form has a wrong method attribute

`<form method="'post'&#10;                                      " ...`