### PR TITLE
Add template to display related items

### DIFF
--- a/news/111.feature
+++ b/news/111.feature
@@ -1,0 +1,2 @@
+Add display template for RelatedItemsWidget. No longer only render uuids.
+[pbauer]

--- a/plone/app/z3cform/configure.zcml
+++ b/plone/app/z3cform/configure.zcml
@@ -150,6 +150,13 @@
       template="templates/link_input.pt"
       />
 
+  <z3c:widgetTemplate
+      mode="display"
+      widget=".interfaces.IRelatedItemsWidget"
+      layer=".interfaces.IPloneFormLayer"
+      template="templates/relateditems_display.pt"
+      />
+
   <browser:page
       name="z3cform_validate_field"
       for="*"

--- a/plone/app/z3cform/templates/relateditems_display.pt
+++ b/plone/app/z3cform/templates/relateditems_display.pt
@@ -1,0 +1,41 @@
+<span id="form-widgets-fieldname"
+      class="relateditems-widget textline-field"
+      i18n:domain="plone"
+      tal:define="plone_view nocall:context/@@plone;
+                  normalizeString python:plone_view.normalizeString;
+                  items python: view.items();
+                  "
+      tal:condition="items"
+      tal:attributes="id python:'form-widgets-{}'.format(view.__name__);
+                      class python: 'relateditems-widget {}-field'.format(normalizeString(view.field.__class__.__name__));
+                      ">
+    <div>
+        <ul>
+          <li tal:repeat="item items">
+            <span tal:define="item_type           python:item.portal_type;
+                              item_type_class     python:item.ContentTypeClass();
+                              item_wf_state_class python:item.ReviewStateClass();
+                              appendViewAction    python:item.appendViewAction();
+                              item_url            python:item.getURL();
+                              item_url            python:item_url+'/view' if appendViewAction else item_url;"
+                  tal:attributes="title item_type">
+
+              <a tal:attributes="href item_url">
+                <img class="mime-icon"
+                     tal:condition="python:item_type =='File'"
+                     tal:attributes="src python:item.MimeTypeIcon();">
+
+                <span tal:attributes="class string:$item_type_class $item_wf_state_class url;"
+                      tal:content="python:item.Title()">
+                    Title
+                </span>
+                <span class="discreet"
+                      tal:content="python:item.Description()">
+                    Description
+                </span>
+              </a>
+            </span>
+          </li>
+        </ul>
+    </div>
+</span>

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -626,7 +626,6 @@ class RelatedItemsWidget(BaseWidget, z3cform_TextWidget):
         Query the catalog for the widget-value (uuids) to only display items
         that the user is allowed to see. Accessing the value with e.g.
         getattr(self.context, self.__name__) would yield the items unfiltered.
-        To keep the order intact query each uuid individually.
         Uses IContentListing for easy access to MimeTypeIcon and more.
         """
         results = []
@@ -634,18 +633,19 @@ class RelatedItemsWidget(BaseWidget, z3cform_TextWidget):
             return results
         separator = getattr(self, 'separator', ';')
         uuids = self.value.split(separator)
-        if not isinstance(uuids, (list, tuple, set)):
-            uuids = [uuids]
 
         try:
             catalog = getToolByName(self.context, 'portal_catalog')
         except AttributeError:
             catalog = getToolByName(getSite(), 'portal_catalog')
 
+        brains = catalog(UID=uuids)
+        # restore original order
+        brains = {i.UID: i for i in brains}
         for uuid in uuids:
-            brains = catalog(UID=uuid)
-            if brains:
-                results.append(brains[0])
+            brain = brains.get(uuid, None)
+            if brain:
+                results.append(brain)
         return IContentListing(results)
 
 

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -641,9 +641,8 @@ class RelatedItemsWidget(BaseWidget, z3cform_TextWidget):
 
         brains = catalog(UID=uuids)
         # restore original order
-        brains = {i.UID: i for i in brains}
-        brains = [brains[uuid] for uuid in uuids if brains.get(uuid)]
-        return IContentListing(brains)
+        results = sorted(brains, key=lambda brain: uuids.index(brain.UID))
+        return IContentListing(results)
 
 
 @implementer_only(IQueryStringWidget)

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -642,11 +642,8 @@ class RelatedItemsWidget(BaseWidget, z3cform_TextWidget):
         brains = catalog(UID=uuids)
         # restore original order
         brains = {i.UID: i for i in brains}
-        for uuid in uuids:
-            brain = brains.get(uuid, None)
-            if brain:
-                results.append(brain)
-        return IContentListing(results)
+        brains = [brains[uuid] for uuid in uuids if brains.get(uuid)]
+        return IContentListing(brains)
 
 
 @implementer_only(IQueryStringWidget)


### PR DESCRIPTION
Display items from RelationChoice and RelationList fields instead of showing only uuids.

As discussed in https://community.plone.org/t/widget-view-shows-uid-value/4352/5

Display with this change:
![related](https://user-images.githubusercontent.com/453208/77223704-4b714100-6b5f-11ea-855b-c6e209f1c25c.png)

Display before:
![related_before](https://user-images.githubusercontent.com/453208/77223754-a145e900-6b5f-11ea-96b2-8de18cfaa22b.png)
