### PR TITLE
Fixed repeat syntax in multi input to also work in Zope 4.5.

### DIFF
--- a/news/116.bugfix
+++ b/news/116.bugfix
@@ -1,0 +1,2 @@
+Fixed repeat syntax in multi input to also work in Zope 4.5.
+[maurits]

--- a/plone/app/z3cform/templates/multi_input.pt
+++ b/plone/app/z3cform/templates/multi_input.pt
@@ -4,7 +4,8 @@
              tal:define="hidden python:widget.mode == 'hidden';
                          showLabel view/showLabel;
                          checkbox_disabled python:not view.allowRemoving and 'disabled' or nothing;
-                         key_widget python:view.key_widgets[repeat['widget'].index()];
+                         index repeat/widget/index;
+                         key_widget python:view.key_widgets[index];
                          error widget/error;
                          key_error key_widget/error|nothing;
                          error_class python:(error or key_error) and ' error' or '';


### PR DESCRIPTION
I now use path expression `index repeat/widget/index`. When `repeat/widget/index` is callable, this will call it, otherwise you simply get the value. This should work in older and newer Zope.

Fixes https://github.com/plone/plone.app.z3cform/issues/116

Strangely, in my case after this I get a different error:

```
   - __traceback_info__: (view.key_widgets[index])
  Module <string>, line 1, in <module>
IndexError: list index out of range
```

When I check, `view.key_widgets` (in `z3c.form`) is an empty list. So there is more going on here, but this seems specific to my form.
But the fix should be good.

Note that this template is an override for a template in `z3c.form`, where it has the same problem, just like a few other templates.