### PR TITLE
add converter to use a date widget on a datetime field

### DIFF
--- a/news/151.bugfix
+++ b/news/151.bugfix
@@ -1,0 +1,1 @@
+Allow DateFieldWidget to be used on schema.datetime. See #151. [jensens]

--- a/news/151.feature
+++ b/news/151.feature
@@ -1,0 +1,1 @@
+Add `default_time` attribute/argument to Date- and DatetimeWidget to allow the converter to set a custom time when nothing was given. [jensens]

--- a/plone/app/z3cform/configure.zcml
+++ b/plone/app/z3cform/configure.zcml
@@ -79,6 +79,7 @@
 
   <adapter factory=".converters.DatetimeWidgetConverter" />
   <adapter factory=".converters.DateWidgetConverter" />
+  <adapter factory=".converters.DateWidgetToDatetimeConverter" />
   <adapter factory=".converters.TimeWidgetConverter" />
   <adapter factory=".converters.SelectWidgetConverter" />
   <adapter factory=".converters.SequenceSelectWidgetConverter" />

--- a/plone/app/z3cform/converters.py
+++ b/plone/app/z3cform/converters.py
@@ -104,7 +104,13 @@ class DatetimeWidgetConverter(BaseDataConverter):
         if len(tmp) == 2 and ":" in tmp[1]:
             value += tmp[1].split(":")
         else:
-            value += ["00", "00"]
+            default_time = self.widget.default_time
+            default_time = (
+                default_time(self.widget.context)
+                if safe_callable(default_time)
+                else default_time
+            )
+            value += default_time.split(":")
 
         # TODO: respect the selected zone from the widget and just fall back
         # to default_zone
@@ -148,11 +154,17 @@ class DateWidgetToDatetimeConverter(BaseDataConverter):
         """
         if not value:
             return self.field.missing_value
-        tmp = value.split("T")
         value = value.split("-")
         if len(value) != 3:
             return self.field.missing_value
-        value += ["00", "00"]
+
+        default_time = self.widget.default_time
+        default_time = (
+            default_time(self.widget.context)
+            if safe_callable(default_time)
+            else default_time
+        )
+        value += default_time.split(":")
 
         # TODO: respect the selected zone from the widget and just fall back
         # to default_zone

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -127,11 +127,24 @@ class BaseWidget(Widget):
 
 @implementer_only(IDateWidget)
 class DateWidget(BaseWidget, z3cform_TextWidget):
-    """Date widget for z3c.form."""
+    """Date widget for z3c.form.
 
+    :param default_timezone: A Olson DB/pytz timezone identifier or a callback
+                             returning such an identifier.
+    :type default_timezone: String or callback
+
+    :param default_time: Time used by converter as fallback if no time was set in UI.
+    :type default_time: String or callback
+
+    The default_timezone and default_time arguments are only used if a datewidget is
+    used on a datetime field. If used on a date field they are ignored.
+    """
     _base_type = "date"
     _converter = DateWidgetConverter
     _formater = "date"
+
+    default_timezone = None
+    default_time = "00:00:00"
 
     pattern = "date-picker"
     pattern_options = BaseWidget.pattern_options.copy()
@@ -205,14 +218,18 @@ class DatetimeWidget(DateWidget):
                              returning such an identifier.
     :type default_timezone: String or callback
 
+    :param default_time: Time used by converter as fallback if no time was set in UI.
+    :type default_time: String or callback
     """
 
     _base_type = "datetime-local"
     _converter = DatetimeWidgetConverter
     _formater = "dateTime"
 
-    pattern = "datetime-picker"
     default_timezone = None
+    default_time = "00:00:00"
+
+    pattern = "datetime-picker"
 
 
 @implementer_only(ITimeWidget)


### PR DESCRIPTION
In past one could use the `zope.schema.datetime` field with a `DatetimeWidget` and set a pattern-option `"time": False` to  switch off selecting a time in the form. This got you a full datetime stored (with timezone!), and there are use cases where this is needed.

Now, with native browser widget this is not possible anymore and the feature is broken (regression).

To get the feature back, I register here a new converter which kicks in if a `DateFieldWidet` is used on a `zope.schema.datetime` with the same behavior: setting the time to "00:00". 

This implies one need to touch all schemas when migrating from 5.2 to 6.0b1. 