### PR TITLE
Remove the before 1900 dates formatting hack.

### DIFF
--- a/news/152.bugfix
+++ b/news/152.bugfix
@@ -1,0 +1,3 @@
+Removed formatting hack for dates before 1900. 
+This was fixed in Python 3.2. 
+[jensens]

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -189,12 +189,7 @@ class DateWidget(BaseWidget, z3cform_TextWidget):
             self._formater,
             "short",
         )
-        if field_value.year > 1900:
-            return formatter.format(field_value)
-
-        # due to fantastic datetime.strftime we need this hack
-        # for now ctime is default
-        return field_value.ctime()
+        return formatter.format(field_value)
 
 
 @implementer_only(IDatetimeWidget)


### PR DESCRIPTION
This was [fixed in Python 3.2](https://bugs.python.org/issue1777412).
Now the lowest date here is year 1, this restriction comes from Python `datetime` package itself.