### PR TITLE
Allow non-default fieldset labels to be translated

### DIFF
--- a/news/87.bugfix
+++ b/news/87.bugfix
@@ -1,0 +1,2 @@
+Allow non-default fieldset labels to be translated
+[mtrebron]

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -122,9 +122,11 @@
                                                   class string:kssattr-fieldset-${fieldset_name};
                                                   data-fieldset fieldset_name">
 
-                                      <legend tal:condition="fieldset_label"
-                                              tal:attributes="id string:fieldsetlegend-${fieldset_name}"
-                                              tal:content="fieldset_label">Form name</legend>
+                                      <legend 
+                                          i18n:translate=""
+                                          tal:condition="fieldset_label"
+                                          tal:attributes="id string:fieldsetlegend-${fieldset_name}"
+                                          tal:content="fieldset_label">Form name</legend>
 
                                       <p i18n:translate=""
                                          tal:define="group_description group/description|nothing"


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.z3cform/issues/87