### PR TITLE
Remove invalid "unicode control characters" for `TextareaWidget` value

### DIFF
--- a/news/167.bugfix
+++ b/news/167.bugfix
@@ -1,0 +1,2 @@
+Remove invalid unicode control characters for `TextareaWidget`
+[petschki]

--- a/plone/app/z3cform/tests/test_utils.py
+++ b/plone/app/z3cform/tests/test_utils.py
@@ -154,6 +154,7 @@ class TestUtils(unittest.TestCase):
 
     def test_unicode_control_character_removal(self):
         from plone.app.z3cform.utils import remove_invalid_xml_characters
+
         for x in range(32):
             if x in (9, 10, 13):
                 self.assertTrue(remove_invalid_xml_characters(chr(x)) == chr(x))

--- a/plone/app/z3cform/tests/test_utils.py
+++ b/plone/app/z3cform/tests/test_utils.py
@@ -151,3 +151,11 @@ class TestUtils(unittest.TestCase):
                 "http://plone.org",
             )
         )
+
+    def test_unicode_control_character_removal(self):
+        from plone.app.z3cform.utils import remove_invalid_xml_characters
+        for x in range(32):
+            if x in (9, 10, 13):
+                self.assertTrue(remove_invalid_xml_characters(chr(x)) == chr(x))
+            else:
+                self.assertTrue(remove_invalid_xml_characters(chr(x)) == "")

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -1700,6 +1700,24 @@ class RichTextWidgetTests(unittest.TestCase):
         base_args = widget._base_args()
         self.assertEqual(base_args["value"], "Lorem ipsum \u2026")
 
+    def test_unicode_control_characters_value(self):
+        # lxml doesn't allow unicode control characters.
+        # see
+        from plone.app.textfield.value import RichTextValue
+        from plone.app.z3cform.widgets.richtext import RichTextWidget
+
+        widget = FieldWidget(self.field, RichTextWidget(self.request))
+        # set the context so we can get tinymce settings
+        widget.context = self.portal
+        widget.value = RichTextValue(
+            "Lorem \u0000 ip\u001Fsum \n\u0002 dolorem \uF600"
+        )
+        widget.mode = "input"
+        self.assertIn(
+            ">Lorem  ipsum  dolorem \uF600</textarea>",
+            widget.render(),
+        )
+
     def _set_mimetypes(self, default="text/html", allowed=("text/html")):
         """Set portal's mimetype settings."""
         if IMarkupSchema:

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -1709,12 +1709,10 @@ class RichTextWidgetTests(unittest.TestCase):
         widget = FieldWidget(self.field, RichTextWidget(self.request))
         # set the context so we can get tinymce settings
         widget.context = self.portal
-        widget.value = RichTextValue(
-            "Lorem \u0000 ip\u001Fsum \n\u0002 dolorem \uF600"
-        )
+        widget.value = RichTextValue("Lorem \u0000 ip\u001Fsum\n\u0002 dolorem\r\t")
         widget.mode = "input"
         self.assertIn(
-            ">Lorem  ipsum  dolorem \uF600</textarea>",
+            ">Lorem  ipsum\n dolorem&#13;\t</textarea>",
             widget.render(),
         )
 

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -181,3 +181,13 @@ def get_context_url(context):
     else:
         url = get_portal_url(context)
     return url
+
+
+def remove_invalid_xml_characters(txt):
+    # remove occurrences of the unicode "control characters"
+    # as they are invalid XML characters
+    # see https://en.wikipedia.org/wiki/Valid_characters_in_XML and
+    # https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+    #
+    invalid_keys = dict.fromkeys(range(32))
+    return txt.translate(invalid_keys)

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -189,7 +189,7 @@ def get_context_url(context):
 # chr(10) = "\n"
 # chr(13) = "\r"
 
-unicode_ctl_chr_map = dict.fromkeys([x for x in range(32) if x not in (9, 10, 13)])
+_unicode_ctl_chr_map = dict.fromkeys([x for x in range(32) if x not in (9, 10, 13)])
 
 
 def remove_invalid_xml_characters(txt):
@@ -197,4 +197,4 @@ def remove_invalid_xml_characters(txt):
     # as they are invalid XML characters
     # see https://en.wikipedia.org/wiki/Valid_characters_in_XML and
     # https://en.wikipedia.org/wiki/C0_and_C1_control_codes
-    return txt.translate(unicode_ctl_chr_map)
+    return txt.translate(_unicode_ctl_chr_map)

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -182,16 +182,18 @@ def get_context_url(context):
         url = get_portal_url(context)
     return url
 
+# Invalid XML unicode control characters
+# NOTE: these control characters are allowed:
+# chr(9) = "\t"
+# chr(10) = "\n"
+# chr(13) = "\r"
+
+unicode_ctl_chr_map = dict.fromkeys([x for x in range(32) if x not in (9, 10, 13)])
+
 
 def remove_invalid_xml_characters(txt):
     # remove occurrences of the unicode "control characters"
     # as they are invalid XML characters
     # see https://en.wikipedia.org/wiki/Valid_characters_in_XML and
     # https://en.wikipedia.org/wiki/C0_and_C1_control_codes
-    # NOTE: these control characters are allowed:
-    # chr(9) = "\t"
-    # chr(10) = "\n"
-    # chr(13) = "\r"
-
-    invalid_keys = dict.fromkeys([x for x in range(32) if x not in (9, 10, 13)])
-    return txt.translate(invalid_keys)
+    return txt.translate(unicode_ctl_chr_map)

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -182,6 +182,7 @@ def get_context_url(context):
         url = get_portal_url(context)
     return url
 
+
 # Invalid XML unicode control characters
 # NOTE: these control characters are allowed:
 # chr(9) = "\t"

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -188,6 +188,10 @@ def remove_invalid_xml_characters(txt):
     # as they are invalid XML characters
     # see https://en.wikipedia.org/wiki/Valid_characters_in_XML and
     # https://en.wikipedia.org/wiki/C0_and_C1_control_codes
-    #
-    invalid_keys = dict.fromkeys(range(32))
+    # NOTE: these control characters are allowed:
+    # chr(9) = "\t"
+    # chr(10) = "\n"
+    # chr(13) = "\r"
+
+    invalid_keys = dict.fromkeys([x for x in range(32) if x not in (9, 10, 13)])
     return txt.translate(invalid_keys)

--- a/plone/app/z3cform/widgets/patterns.py
+++ b/plone/app/z3cform/widgets/patterns.py
@@ -1,4 +1,5 @@
 from lxml import etree
+from plone.app.z3cform.utils import remove_invalid_xml_characters
 
 import collections
 import json
@@ -329,7 +330,7 @@ class TextareaWidget(BaseWidget):
         :param value: Set value of element.
         :type value: string
         """
-        self.el.text = value
+        self.el.text = remove_invalid_xml_characters(value)
 
     def _del_value(self):
         """Set empty string as value of element."""


### PR DESCRIPTION
There are several issues and questions on community.plone.org reporting this traceback and we've been hit by this today in latest Plone `6.0.4` with customer pasted text.

```
  ...
  File "/home/workspace/src/plone.app.z3cform/plone/app/z3cform/tests/test_widgets.py", line 1716, in test_unicode_control_characters_value
    widget.render(),
  File "/home/workspace/src/plone.app.z3cform/plone/app/z3cform/widgets/richtext.py", line 104, in render
    return renderer(self)
  File "/home/workspace/src/plone.app.z3cform/plone/app/z3cform/widgets/richtext.py", line 178, in tinymce_richtextwidget_render
    return RichTextWidget.render_input_mode(widget)
  File "/home/workspace/src/plone.app.z3cform/plone/app/z3cform/widgets/richtext.py", line 129, in render_input_mode
    textarea_widget = self._base(None, None, **base_args)
  File "/home/workspace/src/plone.app.z3cform/plone/app/z3cform/widgets/patterns.py", line 319, in __init__
    self.value = value
  File "/home/workspace/src/plone.app.z3cform/plone/app/z3cform/widgets/patterns.py", line 333, in _set_value
    self.el.text = value
  File "src/lxml/etree.pyx", line 1042, in lxml.etree._Element.text.__set__
  File "src/lxml/apihelpers.pxi", line 748, in lxml.etree._setNodeText
  File "src/lxml/apihelpers.pxi", line 736, in lxml.etree._createTextNode
  File "src/lxml/apihelpers.pxi", line 1541, in lxml.etree._utf8
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control character
```

This fixes it by remove all invalid unicode control characters before setting it to `lxml.Element("textarea").text`