### PR TITLE
Use html 5 email field for plone.schema email fields

### DIFF
--- a/news/173.feature
+++ b/news/173.feature
@@ -1,0 +1,3 @@
+Introduce new Email-Widget which is used for `plone.schema.email.IEmail` fields.
+It uses the input type `email`.
+[jensens]

--- a/plone/app/z3cform/interfaces.py
+++ b/plone/app/z3cform/interfaces.py
@@ -69,6 +69,7 @@ class IRichTextWidget(patextfield_IRichTextWidget):
 class ILinkWidget(ITextWidget):
     """Marker interface for the enhanced link widget."""
 
+
 class IEmailWidget(ITextWidget):
     """Marker interface for the dumb email widget."""
 

--- a/plone/app/z3cform/interfaces.py
+++ b/plone/app/z3cform/interfaces.py
@@ -69,6 +69,9 @@ class IRichTextWidget(patextfield_IRichTextWidget):
 class ILinkWidget(ITextWidget):
     """Marker interface for the enhanced link widget."""
 
+class IEmailWidget(ITextWidget):
+    """Marker interface for the dumb email widget."""
+
 
 class ISingleCheckBoxBoolWidget(ISingleCheckBoxWidget):
     """Marker interface for the SingleCheckboxBoolWidget."""

--- a/plone/app/z3cform/templates/email_input.pt
+++ b/plone/app/z3cform/templates/email_input.pt
@@ -1,0 +1,52 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag=""
+>
+  <input class=""
+         id=""
+         accesskey=""
+         alt=""
+         lang=""
+         maxlength=""
+         name=""
+         size=""
+         style=""
+         tabindex=""
+         title=""
+         type="email"
+         value=""
+         tal:attributes="
+           id view/id;
+           name view/name;
+           required python:view.required and 'required' or None;
+           class python:'form-control {0}{1}'.format(view.klass, view.error and ' is-invalid' or '');
+           style view/style;
+           title view/title;
+           lang view/lang;
+           onclick view/onclick;
+           ondblclick view/ondblclick;
+           onmousedown view/onmousedown;
+           onmouseup view/onmouseup;
+           onmouseover view/onmouseover;
+           onmousemove view/onmousemove;
+           onmouseout view/onmouseout;
+           onkeypress view/onkeypress;
+           onkeydown view/onkeydown;
+           onkeyup view/onkeyup;
+           value view/value;
+           disabled view/disabled;
+           tabindex view/tabindex;
+           onfocus view/onfocus;
+           onblur view/onblur;
+           onchange view/onchange;
+           readonly view/readonly;
+           alt view/alt;
+           accesskey view/accesskey;
+           onselect view/onselect;
+           size view/size;
+           maxlength view/maxlength;
+           placeholder view/placeholder;
+           autocapitalize view/autocapitalize;
+         "
+  />
+</html>

--- a/plone/app/z3cform/widgets.zcml
+++ b/plone/app/z3cform/widgets.zcml
@@ -206,6 +206,20 @@
       mode="input"
       />
 
+  <!-- email -->
+  <adapter
+      factory=".widgets.email.EmailFieldWidget"
+      for="plone.schema.email.IEmail
+           plone.app.z3cform.interfaces.IPloneFormLayer"
+      />
+
+  <z3c:widgetTemplate
+      widget=".interfaces.IEmailWidget"
+      template="templates/email_input.pt"
+      layer=".interfaces.IPloneFormLayer"
+      mode="input"
+      />
+
   <!-- z3c.form overrides -->
 
   <z3c:widgetTemplate

--- a/plone/app/z3cform/widgets/email.py
+++ b/plone/app/z3cform/widgets/email.py
@@ -5,13 +5,11 @@ from z3c.form.widget import FieldWidget
 from zope.interface import implementer
 from zope.interface import implementer_only
 
-import json
-
 
 @implementer_only(IEmailWidget)
 class EmailWidget(z3cform_TextWidget):
-    """Implementation of dumb email widget.
-    """
+    """Implementation of dumb email widget."""
+
 
 @implementer(IFieldWidget)
 def EmailFieldWidget(field, request):

--- a/plone/app/z3cform/widgets/email.py
+++ b/plone/app/z3cform/widgets/email.py
@@ -1,0 +1,18 @@
+from plone.app.z3cform.interfaces import IEmailWidget
+from z3c.form.browser.text import TextWidget as z3cform_TextWidget
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.widget import FieldWidget
+from zope.interface import implementer
+from zope.interface import implementer_only
+
+import json
+
+
+@implementer_only(IEmailWidget)
+class EmailWidget(z3cform_TextWidget):
+    """Implementation of dumb email widget.
+    """
+
+@implementer(IFieldWidget)
+def EmailFieldWidget(field, request):
+    return FieldWidget(field, EmailWidget(request))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
 
-version = "4.2.2.dev0"
+version = "4.3.0.dev0"
 
 long_description = (
     read("README.rst")


### PR DESCRIPTION
Currently email input from `plone.schema.email` is not validated on the client because it does not use the email field type. In past it was sometimes a problem using this field, since browsers did not support this field types well enough. Meanwhile this is not a problem any more.