### PR TITLE
Add `row` container to enable column layout for fields using `wrapper_css_class`

### DIFF
--- a/news/158.feature
+++ b/news/158.feature
@@ -1,0 +1,2 @@
+Add `row` container to enable column layouts for fields with `wrapper_css_class`.
+[petschki]

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -138,13 +138,15 @@
                 >Form name</legend>
 
                 <metal:define define-macro="widget_rendering">
-                  <tal:widgets repeat="widget python:view.widgets.values()">
-                    <metal:field-slot define-slot="field">
-                      <metal:field define-macro="field">
-                        <tal:widget tal:replace="structure widget/@@ploneform-render-widget" />
-                      </metal:field>
-                    </metal:field-slot>
-                  </tal:widgets>
+                  <div class="row">
+                    <tal:widgets repeat="widget python:view.widgets.values()">
+                      <metal:field-slot define-slot="field">
+                        <metal:field define-macro="field">
+                          <tal:widget tal:replace="structure widget/@@ploneform-render-widget" />
+                        </metal:field>
+                      </metal:field-slot>
+                    </tal:widgets>
+                  </div>
                 </metal:define>
               </fieldset>
 


### PR DESCRIPTION
fixes #158
