### PR TITLE
Ignore form validation if `ignoreRequiredOnExtract` is set

### DIFF
--- a/news/179.bugfix
+++ b/news/179.bugfix
@@ -1,0 +1,2 @@
+Ignore form validation when `ignoreRequiredOnExtract` is set.
+[petschki]

--- a/plone/app/z3cform/templates/macros.pt
+++ b/plone/app/z3cform/templates/macros.pt
@@ -87,7 +87,7 @@
                 unload_protection python:enable_unload_protection and 'pat-formunloadalert';
                 enable_autofocus view/enable_autofocus|python:True;
                 autofocus python:enable_autofocus and 'pat-formautofocus';
-                validation python:'pat-validation' if True else '';
+                validation python:'pat-validation' if not view.ignoreRequiredOnExtract else '';
                 has_groups python:bool(groups);
                 form_tabbing python:(has_groups and enable_form_tabbing) and 'enableFormTabbing pat-autotoc' or '';
                 show_default_label python:has_groups and default_fieldset_label and len(view.widgets);


### PR DESCRIPTION
fixes #179 
see also https://github.com/plone/plone.schemaeditor/issues/106