### PR TITLE
Remove invalid "unicode control characters" for TextareaWidget value (Plone 5.2)

### DIFF
--- a/news/167.bugfix
+++ b/news/167.bugfix
@@ -1,0 +1,2 @@
+Remove invalid unicode control characters for `TextareaWidget`
+[petschki] [ewohnlich]

--- a/plone/app/z3cform/tests/test_utils.py
+++ b/plone/app/z3cform/tests/test_utils.py
@@ -124,3 +124,12 @@ class TestUtils(unittest.TestCase):
             'https://plone.org',
             'http://plone.org',
         ))
+
+    def test_unicode_control_character_removal(self):
+        from plone.app.z3cform.utils import remove_invalid_xml_characters
+
+        for x in range(32):
+            if x in (9, 10, 13):
+                self.assertTrue(remove_invalid_xml_characters(chr(x)) == chr(x))
+            else:
+                self.assertTrue(remove_invalid_xml_characters(chr(x)) == "")

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -1586,6 +1586,23 @@ class RichTextWidgetTests(unittest.TestCase):
             '/plone',
         )
 
+
+    def test_unicode_control_characters_value(self):
+        # lxml doesn't allow unicode control characters.
+        # see
+        from plone.app.textfield.value import RichTextValue
+        from plone.app.z3cform.widget import RichTextWidget
+
+        widget = FieldWidget(self.field, RichTextWidget(self.request))
+        # set the context so we can get tinymce settings
+        widget.context = self.portal
+        widget.value = RichTextValue("Lorem \u0000 ip\u001Fsum\n\u0002 dolorem\r\t")
+        widget.mode = "input"
+        self.assertIn(
+            ">Lorem  ipsum\n dolorem&#13;\t</textarea>",
+            widget.render(),
+        )
+
     def test_widget_values(self):
         from plone.app.z3cform.widget import RichTextWidget
         from plone.app.textfield.value import RichTextValue

--- a/plone/app/z3cform/utils.py
+++ b/plone/app/z3cform/utils.py
@@ -5,9 +5,9 @@ from Products.CMFCore.interfaces import IFolderish
 from six.moves import urllib
 from zope.component.hooks import getSite
 
-
 try:
     from zope.globalrequest import getRequest
+
     getRequest  # pyflakes
 except ImportError:
     # Fake it
@@ -121,3 +121,20 @@ def is_same_domain(url1, url2):
     purl1 = urllib.parse.urlparse(url1)
     purl2 = urllib.parse.urlparse(url2)
     return purl1.scheme == purl2.scheme and purl1.netloc == purl2.netloc
+
+
+# Invalid XML unicode control characters
+# NOTE: these control characters are allowed:
+# chr(9) = "\t"
+# chr(10) = "\n"
+# chr(13) = "\r"
+
+_unicode_ctl_chr_map = dict.fromkeys([x for x in range(32) if x not in (9, 10, 13)])
+
+
+def remove_invalid_xml_characters(txt):
+    # remove occurrences of the unicode "control characters"
+    # as they are invalid XML characters
+    # see https://en.wikipedia.org/wiki/Valid_characters_in_XML and
+    # https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+    return txt.translate(_unicode_ctl_chr_map)

--- a/plone/app/z3cform/widget.py
+++ b/plone/app/z3cform/widget.py
@@ -35,6 +35,7 @@ from plone.app.z3cform.interfaces import ISelectWidget
 from plone.app.z3cform.interfaces import ISingleCheckBoxBoolWidget
 from plone.app.z3cform.utils import call_callables
 from plone.app.z3cform.utils import closest_content
+from plone.app.z3cform.utils import remove_invalid_xml_characters
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
@@ -752,6 +753,10 @@ class RichTextWidget(BaseWidget, patext_RichTextWidget):
         return super(RichTextWidget, self).render()
 
     def render_input_mode(self):
+            if self.value and self.value.raw:
+                raw = self.value.raw
+                raw = remove_invalid_xml_characters(raw)
+                self.value = RichTextValue(raw, mimeType=self.value.mimeType, encoding=self.value.encoding)
             # MODE "INPUT"
             rendered = ''
             allowed_mime_types = self.allowedMimeTypes()


### PR DESCRIPTION
This is a backport of https://github.com/plone/plone.app.z3cform/pull/167 for Plone 5.2. This package has been refactored on master so this not an exact copy of petschki's fix. The fix is applied in plone.app.z3cform.widget.RichTextWidget.render_input_mode which I believe is analogous. I had to rebuild the entire RichTextValue with this method (I don't think you can change just the raw text of one of these objects after instantiation?)