### PR TITLE
Implement missing PasswordWigdet adapter

### DIFF
--- a/news/193.bugfix
+++ b/news/193.bugfix
@@ -1,0 +1,2 @@
+Implement missing PasswordWidget adapter.
+[petschki]

--- a/plone/app/z3cform/interfaces.py
+++ b/plone/app/z3cform/interfaces.py
@@ -103,6 +103,10 @@ class IEmailWidget(ITextWidget):
     """Marker interface for the dumb email widget."""
 
 
+class IPasswordWidget(ITextWidget):
+    """Marker interface for the password widget."""
+
+
 class ISubmitWidget(ISubmitWidgetBase):
     """Marker interface for SubmitWidget."""
 

--- a/plone/app/z3cform/widgets.zcml
+++ b/plone/app/z3cform/widgets.zcml
@@ -61,12 +61,6 @@
            plone.app.z3cform.interfaces.IPloneFormLayer"
       />
 
-  <adapter
-      factory=".widgets.text.TextFieldWidget"
-      for="zope.schema.interfaces.IPassword
-           plone.app.z3cform.interfaces.IPloneFormLayer"
-      />
-
   <z3c:widgetTemplate
       widget=".interfaces.ITextWidget"
       template="templates/text_input.pt"
@@ -288,6 +282,21 @@
   <z3c:widgetTemplate
       widget=".interfaces.IEmailWidget"
       template="templates/email_input.pt"
+      layer=".interfaces.IPloneFormLayer"
+      mode="input"
+      />
+
+
+  <!-- password -->
+  <adapter
+      factory=".widgets.password.PasswordFieldWidget"
+      for="zope.schema.interfaces.IPassword
+           .interfaces.IPloneFormLayer"
+      />
+
+  <z3c:widgetTemplate
+      widget=".interfaces.IPasswordWidget"
+      template="templates/password_input.pt"
       layer=".interfaces.IPloneFormLayer"
       mode="input"
       />

--- a/plone/app/z3cform/widgets/password.py
+++ b/plone/app/z3cform/widgets/password.py
@@ -1,0 +1,19 @@
+from plone.app.z3cform.interfaces import IPasswordWidget
+from plone.app.z3cform.widgets.base import HTMLTextInputWidget
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.widget import FieldWidget
+from z3c.form.widget import Widget
+from zope.interface import implementer
+from zope.interface import implementer_only
+
+
+@implementer_only(IPasswordWidget)
+class PasswordWidget(HTMLTextInputWidget, Widget):
+    """enhanced text widget"""
+
+    klass = "password-widget"
+
+
+@implementer(IFieldWidget)
+def PasswordFieldWidget(field, request):
+    return FieldWidget(field, PasswordWidget(request))


### PR DESCRIPTION
Plone 6.1 login has currently an `input[type=text]` as password field. This fixes it.