### PR TITLE
Add support for accept attribute on file input (4.3.x branch)

### DIFF
--- a/news/198.feature
+++ b/news/198.feature
@@ -1,0 +1,14 @@
+Add support for the "accept" attribute on file inputs.
+
+If the widget's field - if there is one - has the "accept" attribute set (the
+`NamedImage` field has `image/*` set by default) then this is rendered as an
+`accept` attribute on the file input.
+
+This would restrict the allowed file types before uploading while still being
+checked on the server side.
+
+Fixes: https://github.com/plone/plone.formwidget.namedfile/issues/66
+Depends on:
+- https://github.com/plone/plone.namedfile/pull/158
+- https://github.com/plone/plone.formwidget.namedfile/pull/67
+[thet]

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -149,7 +149,7 @@
          "
   />
   <div class="form-text"
-       tal:condition="view/accept"
+       tal:condition="view/accept|nothing"
        i18n:translate="namedfile_accepted_types"
   >
     Allowed types:

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -133,7 +133,7 @@
   </tal:block>
 
   <input class="form-control"
-         accept="${view/accept}"
+         accept="${view/accept|nothing}"
          type="file"
          tal:define="
            is_invalid python:view.error and 'is-invalid' or '';

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -133,6 +133,7 @@
   </tal:block>
 
   <input class="form-control"
+         accept="${view/accept}"
          type="file"
          tal:define="
            is_invalid python:view.error and 'is-invalid' or '';

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -148,6 +148,13 @@
            class string:form-control $is_invalid;
          "
   />
+  <div class="form-text"
+       tal:condition="view/accept"
+       i18n:translate="namedfile_accepted_types"
+  >
+    Allowed types:
+    <tal:i18n i18n:name="accepted_types">${view/accept}</tal:i18n>.
+  </div>
 
   <script type="text/javascript"
           tal:condition="python:allow_nochange and action != 'replace'"

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -139,7 +139,7 @@
   </tal:block>
 
   <input class="form-control"
-         accept="${view/accept}"
+         accept="${view/accept|nothing}"
          type="file"
          tal:attributes="
            id string:${view/id}-input;

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -151,7 +151,7 @@
          "
   />
   <div class="form-text"
-       tal:condition="view/accept"
+       tal:condition="view/accept|nothing"
        i18n:translate="namedfile_accepted_types"
   >
     Allowed types:

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -139,6 +139,7 @@
   </tal:block>
 
   <input class="form-control"
+         accept="${view/accept}"
          type="file"
          tal:attributes="
            id string:${view/id}-input;

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -150,6 +150,13 @@
            maxlength view/maxlength;
          "
   />
+  <div class="form-text"
+       tal:condition="view/accept"
+       i18n:translate="namedfile_accepted_types"
+  >
+    Allowed types:
+    <tal:i18n i18n:name="accepted_types">${view/accept}</tal:i18n>.
+  </div>
 
   <script type="text/javascript"
           tal:condition="python:allow_nochange and action != 'replace'"

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "plone.base",
         "plone.app.contentlisting",
         "plone.dexterity",
+        "plone.formwidget.namedfile>3.0.3",
         "plone.i18n",
         "plone.protect",
         "plone.registry",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "plone.base",
         "plone.app.contentlisting",
         "plone.dexterity",
-        "plone.formwidget.namedfile>3.0.3",
+        "plone.formwidget.namedfile>=3.1.0",
         "plone.i18n",
         "plone.protect",
         "plone.registry",


### PR DESCRIPTION
If the widget's field - if there is one - has  set (the  field has  set by default) the allowed content types are rendered as  attribute on the file input.

This already restricts the allowed file types before uploading while still being checked on the server side too.

Fixes: https://github.com/plone/plone.formwidget.namedfile/issues/66 Depeds on:
- https://github.com/plone/plone.namedfile/pull/158
- https://github.com/plone/plone.formwidget.namedfile/pull/67