### PR TITLE
Add support for accept attribute on file input.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:
@@ -13,7 +13,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -29,13 +30,15 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml,zcml}]
+[*.{yml,zpt,pt,dtml,zcml,html,xml}]
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
 # 2 space indentation
 indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitmodules}]
 # Tab indentation (no size specified, but view as 4 spaces)

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info
@@ -12,6 +12,7 @@
 # tools related
 build/
 .coverage
+.*project
 coverage.xml
 dist/
 docs/_build
@@ -34,6 +35,7 @@ lib64
 parts/
 pyvenv.cfg
 var/
+local.cfg
 
 # mxdev
 /instance/

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,9 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "b3ba013b"
+commit-id = "d85a300a"
 
 [pyproject]
 dependencies_ignores = "['lxml', 'plone.app.vocabularies']"

--- a/.meta.toml
+++ b/.meta.toml
@@ -6,7 +6,7 @@ template = "default"
 commit-id = "d85a300a"
 
 [pyproject]
-dependencies_ignores = "['lxml', 'plone.app.vocabularies']"
+dependencies_ignores = "['lxml', 'plone.app.vocabularies', 'plone.formwidget.namedfile']"
 codespell_ignores = "iterms"
 
 [gitignore]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/main/config/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/news/198.feature
+++ b/news/198.feature
@@ -1,0 +1,14 @@
+Add support for the "accept" attribute on file inputs.
+
+If the widget's field - if there is one - has the "accept" attribute set (the
+`NamedImage` field has `image/*` set by default) then this is rendered as an
+`accept` attribute on the file input.
+
+This would restrict the allowed file types before uploading while still being
+checked on the server side.
+
+Fixes: https://github.com/plone/plone.formwidget.namedfile/issues/66
+Depends on:
+- https://github.com/plone/plone.namedfile/pull/158
+- https://github.com/plone/plone.formwidget.namedfile/pull/67
+[thet]

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -90,6 +90,7 @@
 
   <input class="form-control ${python:view.error and 'is-invalid' or ''}"
          id="${view/id}-input"
+         accept="${view/accept}"
          disabled="${view/disabled}"
          maxlength="${view/maxlength}"
          name="${view/name}"

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -99,7 +99,7 @@
          type="file"
   />
   <div class="form-text"
-       tal:condition="view/accept"
+       tal:condition="view/accept|nothing"
        i18n:translate="namedfile_accepted_types"
   >
       Allowed types:

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -98,6 +98,13 @@
          size="${view/size}"
          type="file"
   />
+  <div class="form-text"
+       tal:condition="view/accept"
+       i18n:translate="namedfile_accepted_types"
+  >
+      Allowed types:
+    <tal:i18n i18n:name="accepted_types">${view/accept}</tal:i18n>.
+  </div>
 
   <script type="text/javascript"
           tal:condition="python:allow_nochange and action != 'replace'"

--- a/plone/app/z3cform/templates/file_input.pt
+++ b/plone/app/z3cform/templates/file_input.pt
@@ -90,7 +90,7 @@
 
   <input class="form-control ${python:view.error and 'is-invalid' or ''}"
          id="${view/id}-input"
-         accept="${view/accept}"
+         accept="${view/accept|nothing}"
          disabled="${view/disabled}"
          maxlength="${view/maxlength}"
          name="${view/name}"

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -103,7 +103,7 @@
          type="file"
   />
   <div class="form-text"
-       tal:condition="view/accept"
+       tal:condition="view/accept|nothing"
        i18n:translate="namedfile_accepted_types"
   >
       Allowed types:

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -94,7 +94,7 @@
 
   <input class="form-control ${python:view.error and 'is-invalid' or ''}"
          id="${view/id}-input"
-         accept="${view/accept}"
+         accept="${view/accept|nothing}"
          disabled="${view/disabled}"
          maxlength="${view/maxlength}"
          name="${view/name}"

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -102,6 +102,13 @@
          size="${view/size}"
          type="file"
   />
+  <div class="form-text"
+       tal:condition="view/accept"
+       i18n:translate="namedfile_accepted_types"
+  >
+      Allowed types:
+    <tal:i18n i18n:name="accepted_types">${view/accept}</tal:i18n>.
+  </div>
 
   <script type="text/javascript"
           tal:condition="python:allow_nochange and action != 'replace'"

--- a/plone/app/z3cform/templates/image_input.pt
+++ b/plone/app/z3cform/templates/image_input.pt
@@ -94,6 +94,7 @@
 
   <input class="form-control ${python:view.error and 'is-invalid' or ''}"
          id="${view/id}-input"
+         accept="${view/accept}"
          disabled="${view/disabled}"
          maxlength="${view/maxlength}"
          name="${view/name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
+[build-system]
+requires = ["setuptools>=68.2"]
+
 [tool.towncrier]
 directory = "news/"
 filename = "CHANGES.rst"
@@ -126,25 +129,31 @@ ignore-packages = ['lxml', 'plone.app.vocabularies']
 #    "gitpython = ['git']",
 #    "pygithub = ['github']",
 #  ]
-#  """
 ##
 
 [tool.check-manifest]
 ignore = [
     ".editorconfig",
+    ".flake8",
     ".meta.toml",
     ".pre-commit-config.yaml",
-    "tox.ini",
-    ".flake8",
+    "dependabot.yml",
     "mx.ini",
+    "tox.ini",
 
 ]
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pyproject]
 #  check_manifest_ignores = """
 #      "*.map.js",
 #      "*.pyc",
+#  """
+#  check_manifest_extra_lines = """
+#  ignore-bad-ideas = [
+#      "some/test/file/PKG-INFO",
+#  ]
 #  """
 ##
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
-ignore-packages = ['lxml', 'plone.app.vocabularies']
+ignore-packages = ['lxml', 'plone.app.vocabularies', 'plone.formwidget.namedfile']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "plone.app.textfield>=1.3.6",
         "plone.base",
         "plone.app.contentlisting",
+        "plone.formwidget.namedfile>3.0.3",
         "plone.i18n",
         "plone.protect",
         "plone.registry",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "plone.app.textfield>=1.3.6",
         "plone.base",
         "plone.app.contentlisting",
-        "plone.formwidget.namedfile>3.0.3",
+        "plone.formwidget.namedfile>=3.1.0",
         "plone.i18n",
         "plone.protect",
         "plone.registry",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/master/config/default
+# https://github.com/plone/meta/tree/main/config/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -32,6 +32,14 @@ commands =
     echo "Unrecognized environment name {envname}"
     false
 
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  testenv_options = """
+#  basepython = /usr/bin/python3.8
+#  """
+##
+
 [testenv:init]
 description = Prepare environment
 skip_install = true
@@ -63,9 +71,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.11
+    z3c.dependencychecker==2.14.3
 commands =
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -101,7 +109,7 @@ set_env =
 deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.1-dev/constraints.txt
-    
+
 ##
 # Specify additional deps in .meta.toml:
 #  [tox]
@@ -144,11 +152,12 @@ deps =
     coverage
     zope.testrunner
     -c https://dist.plone.org/release/6.1-dev/constraints.txt
-    
+
 commands =
     coverage run --branch --source plone.app.z3cform {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s plone.app.z3cform {posargs}
     coverage report -m --format markdown
     coverage xml
+    coverage html
 extras =
     test
 
@@ -161,19 +170,22 @@ deps =
     build
     towncrier
     -c https://dist.plone.org/release/6.1-dev/constraints.txt
-    
+
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
     # the README that is displayed on PyPI
     towncrier build --version=100.0.0 --yes
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     twine check dist/*
 
 [testenv:circular]
 description = ensure there are no cyclic dependencies
 use_develop = true
 skip_install = false
+# Here we must always constrain the package deps to what is already installed,
+# otherwise we simply get the latest from PyPI, which may not work.
+constrain_package_deps = true
 set_env =
 
 ##
@@ -189,7 +201,7 @@ deps =
     pipdeptree
     pipforester
     -c https://dist.plone.org/release/6.1-dev/constraints.txt
-    
+
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
If the widget's field - if there is one - has  set (the  field has  set by default) the allowed content types are rendered as  attribute on the file input.

This already restricts the allowed file types before uploading while still being checked on the server side too.

Fixes: https://github.com/plone/plone.formwidget.namedfile/issues/66 Depeds on:
- https://github.com/plone/plone.namedfile/pull/158
- https://github.com/plone/plone.formwidget.namedfile/pull/67