### PR TITLE
use label_css_class attribute from widget if available in checkbox_input & radio_input [4.3.x]

### DIFF
--- a/news/#201.feature
+++ b/news/#201.feature
@@ -1,0 +1,2 @@
+Use label_css_class attribute from widget if available in checkbox_input & radio_input
+[MrTango]

--- a/plone/app/z3cform/templates/checkbox_input.pt
+++ b/plone/app/z3cform/templates/checkbox_input.pt
@@ -97,7 +97,7 @@
                onselect view/onselect;
              "
       />
-      <label class="form-check-label ${python:getattr(view, 'label_css_class', False) or False}"
+      <label class="form-check-label ${python:getattr(view, 'label_css_class', '')}"
              for=""
              tal:attributes="
                for item/id;

--- a/plone/app/z3cform/templates/checkbox_input.pt
+++ b/plone/app/z3cform/templates/checkbox_input.pt
@@ -97,7 +97,7 @@
                onselect view/onselect;
              "
       />
-      <label class="form-check-label"
+      <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
              for=""
              tal:attributes="
                for item/id;

--- a/plone/app/z3cform/templates/checkbox_input.pt
+++ b/plone/app/z3cform/templates/checkbox_input.pt
@@ -97,7 +97,7 @@
                onselect view/onselect;
              "
       />
-      <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
+      <label class="form-check-label ${python:getattr(view, 'label_css_class', False) or False}"
              for=""
              tal:attributes="
                for item/id;

--- a/plone/app/z3cform/templates/radio_input.pt
+++ b/plone/app/z3cform/templates/radio_input.pt
@@ -8,7 +8,7 @@
     <input class="form-check-input"
            tal:replace="structure python:view.renderForValue(item['value'])"
     />
-    <label class="form-check-label ${python:getattr(view, 'label_css_class', False) or False}"
+    <label class="form-check-label ${python:getattr(view, 'label_css_class', '')}"
            tal:content="item/label"
            tal:attributes="
              for item/id;

--- a/plone/app/z3cform/templates/radio_input.pt
+++ b/plone/app/z3cform/templates/radio_input.pt
@@ -8,7 +8,7 @@
     <input class="form-check-input"
            tal:replace="structure python:view.renderForValue(item['value'])"
     />
-    <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
+    <label class="form-check-label ${python:getattr(view, 'label_css_class', False) or False}"
            tal:content="item/label"
            tal:attributes="
              for item/id;

--- a/plone/app/z3cform/templates/radio_input.pt
+++ b/plone/app/z3cform/templates/radio_input.pt
@@ -8,7 +8,7 @@
     <input class="form-check-input"
            tal:replace="structure python:view.renderForValue(item['value'])"
     />
-    <label class="form-check-label"
+    <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
            tal:content="item/label"
            tal:attributes="
              for item/id;

--- a/plone/app/z3cform/templates/widget.pt
+++ b/plone/app/z3cform/templates/widget.pt
@@ -1,4 +1,4 @@
-<div class="mb-3 field fieldname-${python:widget.name} widget-mode-${python:widget.mode}${error_class}${empty_class} ${python:getattr(widget, 'wrapper_css_class', False) or False}"
+<div class="mb-3 field fieldname-${python:widget.name} widget-mode-${python:widget.mode}${error_class}${empty_class} ${python: getattr(widget, 'wrapper_css_class', '')}"
      id="formfield-${python:widget.id}"
      metal:define-macro="widget-wrapper"
      data-fieldname="${widget/name}"


### PR DESCRIPTION
Can be used like this, to realize Bootstrap Checkbox/Radio Toggle Buttons.

```
    directives.widget(
        "graduation",
        CheckBoxFieldWidget,
        klass="btn-check",
        label_css_class="btn btn-outline-primary",
    )
    graduation = schema.List(
        required=False,
        title=_("Graduation"),
        value_type=schema.Choice(
            vocabulary="example.AvailableGraduationGroups",
        ),
    )
```