### PR TITLE
use label_css_class attribute from widget if available in checkbox_input & radio_input [master]

### DIFF
--- a/news/#202.feature
+++ b/news/#202.feature
@@ -1,0 +1,2 @@
+Use label_css_class attribute from widget if available in checkbox_input & radio_input
+[MrTango]

--- a/plone/app/z3cform/templates/checkbox_input.pt
+++ b/plone/app/z3cform/templates/checkbox_input.pt
@@ -33,9 +33,8 @@
                id item/id;
              "
       />
-      <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
-             for="${item/id}"
-      >
+      <label class="form-check-label ${python:getattr(view, 'label_css_class', '')}"
+             for="${item/id}">
         <span class="label">${item/label}</span>
       </label>
     </div>

--- a/plone/app/z3cform/templates/checkbox_input.pt
+++ b/plone/app/z3cform/templates/checkbox_input.pt
@@ -33,7 +33,7 @@
                id item/id;
              "
       />
-      <label class="form-check-label"
+      <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
              for="${item/id}"
       >
         <span class="label">${item/label}</span>

--- a/plone/app/z3cform/templates/checkbox_input.pt
+++ b/plone/app/z3cform/templates/checkbox_input.pt
@@ -34,7 +34,8 @@
              "
       />
       <label class="form-check-label ${python:getattr(view, 'label_css_class', '')}"
-             for="${item/id}">
+             for="${item/id}"
+      >
         <span class="label">${item/label}</span>
       </label>
     </div>

--- a/plone/app/z3cform/templates/radio_input.pt
+++ b/plone/app/z3cform/templates/radio_input.pt
@@ -8,7 +8,7 @@
     <input class="form-check-input"
            tal:replace="structure python:view.renderForValue(item['value'])"
     />
-    <label class="form-check-label"
+    <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
            for="${item/id}"
     >${item/label}</label>
   </div>

--- a/plone/app/z3cform/templates/radio_input.pt
+++ b/plone/app/z3cform/templates/radio_input.pt
@@ -8,7 +8,7 @@
     <input class="form-check-input"
            tal:replace="structure python:view.renderForValue(item['value'])"
     />
-    <label class="form-check-label ${python:getattr(view, 'label_css_class', False)}"
+    <label class="form-check-label ${python:getattr(view, 'label_css_class', '')}"
            for="${item/id}"
     >${item/label}</label>
   </div>

--- a/plone/app/z3cform/templates/widget.pt
+++ b/plone/app/z3cform/templates/widget.pt
@@ -1,4 +1,4 @@
-<div class="mb-3 field fieldname-${python:widget.name} widget-mode-${python:widget.mode}${error_class}${empty_class} ${python:getattr(widget, 'wrapper_css_class', False) or ''}"
+<div class="mb-3 field fieldname-${python:widget.name} widget-mode-${python:widget.mode}${error_class}${empty_class} ${python: getattr(widget, 'wrapper_css_class', '')}"
      id="formfield-${python:widget.id}"
      metal:define-macro="widget-wrapper"
      data-fieldname="${widget/name}"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "4.5.0"
+version = "4.5.1.dev0"
 
 long_description = (
     f"{Path('README.rst').read_text()}\n"


### PR DESCRIPTION
Can be used like this, to realize Bootstrap Checkbox/Radio Toggle Buttons.

```
    directives.widget(
        "graduation",
        CheckBoxFieldWidget,
        klass="btn-check",
        label_css_class="btn btn-outline-primary",
    )
    graduation = schema.List(
        required=False,
        title=_("Graduation"),
        value_type=schema.Choice(
            vocabulary="example.AvailableGraduationGroups",
        ),
    )
```