### PR TITLE
No :list for single select (e.g. Choice) widgets.

### DIFF
--- a/news/206.bugfix
+++ b/news/206.bugfix
@@ -1,0 +1,1 @@
+Bugfix: We do not want a `:list` for single selects like a `zope.schema.Choice`. [@jensens]

--- a/plone/app/z3cform/templates/select_input.pt
+++ b/plone/app/z3cform/templates/select_input.pt
@@ -8,7 +8,7 @@
        This behavior hopefully will be gone soon when "pat-select2"
        is upgraded to Select2 >= 4.x -->
   <select id="${view/id}"
-          name="${view/name}${python:':list' if view.pattern != 'select2' else ''}"
+          name="${view/name}${python:':list' if (view.multiple and view.pattern != 'select2') else ''}"
           tal:define="
             items view/items;
             is_tree python:isinstance(items, dict);


### PR DESCRIPTION
We do not need a `:list` for single selects like a `zope.schema.Choice`. 

However, the strange part is, the test https://github.com/plone/Products.CMFPlone/blob/308aa4d03ee6c0ce9d8119ce4c37955153f0bc6f/Products/CMFPlone/tests/AddMoveAndDeleteDocument.txt#L114 ff worked before PR here https://github.com/plone/plone.app.dexterity/pull/387 - even if this only points the import to the non-deprecated place.