### PR TITLE
Fix pattern options for `LinkWidget`

### DIFF
--- a/news/213.bugfix
+++ b/news/213.bugfix
@@ -1,0 +1,2 @@
+Fix pattern options for `LinkWidget`.
+[petschki]

--- a/plone/app/z3cform/widgets/link.py
+++ b/plone/app/z3cform/widgets/link.py
@@ -26,6 +26,8 @@ class LinkWidget(HTMLTextInputWidget, Widget):
             "vocabularyUrl": "{}/@@getVocabulary?name=plone.app.vocabularies.Catalog".format(  # noqa
                 getSite().absolute_url(0),
             ),
+            "rootPath": "/".join(getSite().getPhysicalPath()),
+            "basePath": "/".join(self.context.getPhysicalPath()),
             "maximumSelectionSize": 1,
         }
         return json.dumps(pattern_data)

--- a/plone/app/z3cform/widgets/link.py
+++ b/plone/app/z3cform/widgets/link.py
@@ -22,12 +22,13 @@ class LinkWidget(HTMLTextInputWidget, Widget):
     """
 
     def pattern_data(self):
+        context = self.context or getSite()
         pattern_data = {
             "vocabularyUrl": "{}/@@getVocabulary?name=plone.app.vocabularies.Catalog".format(  # noqa
                 getSite().absolute_url(0),
             ),
             "rootPath": "/".join(getSite().getPhysicalPath()),
-            "basePath": "/".join(self.context.getPhysicalPath()),
+            "basePath": "/".join(context.getPhysicalPath()),
             "maximumSelectionSize": 1,
         }
         return json.dumps(pattern_data)


### PR DESCRIPTION
This came up on a virtualhostmonster hosted site here because `rootUrl` and `baseUrl` are be empty in that case. `ContentBrowserWidget` needs at least the physical root url of the plone site.