### PR TITLE
Provide a context with getPhysicalPath, if missing, in LinkWidget pattern_data

### DIFF
--- a/plone/app/z3cform/widgets/link.py
+++ b/plone/app/z3cform/widgets/link.py
@@ -23,6 +23,8 @@ class LinkWidget(HTMLTextInputWidget, Widget):
 
     def pattern_data(self):
         context = self.context or getSite()
+        if not(hasattr(context, 'getPhysicalPath') and callable(context.getPhysicalPath)):
+            context = getSite()
         pattern_data = {
             "vocabularyUrl": "{}/@@getVocabulary?name=plone.app.vocabularies.Catalog".format(  # noqa
                 getSite().absolute_url(0),


### PR DESCRIPTION
If used in the control panel, it may happen that the context is the control panel and this can lead to have no context.REQUEST, returning an error if LinkWidget is used in the a control panel configlet.
Closes #226