### PR TITLE
Fix `TreeVocabulary` implementation and `AjaxSelectWidget` display template

### DIFF
--- a/news/225.bugfix
+++ b/news/225.bugfix
@@ -1,0 +1,1 @@
+Fix view template for AjaxSelectWidget. @petschki

--- a/news/235.bugfix
+++ b/news/235.bugfix
@@ -1,0 +1,1 @@
+Fix TreeVocabulary implementation. This now also works for "standard" SelectWidget and Select2Widget. @petschki

--- a/plone/app/z3cform/templates/ajaxselect_display.pt
+++ b/plone/app/z3cform/templates/ajaxselect_display.pt
@@ -1,15 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag=""
->
-  <span id="${view/id}"
-        tal:attributes="
-          view/attributes;
-        "
-  ><tal:block condition="view/value" />
+><span id="${view/id}"><tal:block condition="view/value" />
     <span class="badge text-bg-secondary"
           data-token="${python:item['token']}"
           tal:repeat="item python:view.display_items()"
-    >${item/title}</span>
-  </span>
-</html>
+    >${item/title}</span></span></html>

--- a/plone/app/z3cform/templates/select_input.pt
+++ b/plone/app/z3cform/templates/select_input.pt
@@ -16,7 +16,10 @@
           tal:attributes="
             view/attributes;
           "
-  ><tal:block repeat="item items"><optgroup label="${item}"
+  ><option tal:condition="python: is_tree and not view.field.required"
+           id="${view/id}-novalue"
+           value=""></option
+      ><tal:block repeat="item items"><optgroup label="${item}"
                 tal:condition="is_tree"
       ><option id="${group_item/id}"
                 selected="${python:'selected' if group_item['selected'] else None}"

--- a/plone/app/z3cform/templates/select_input.pt
+++ b/plone/app/z3cform/templates/select_input.pt
@@ -16,10 +16,10 @@
           tal:attributes="
             view/attributes;
           "
-  ><option tal:condition="python: is_tree and not view.field.required"
-           id="${view/id}-novalue"
-           value=""></option
-      ><tal:block repeat="item items"><optgroup label="${item}"
+  ><option id="${view/id}-novalue"
+            value=""
+            tal:condition="python: is_tree and not view.field.required"
+    ></option><tal:block repeat="item items"><optgroup label="${item}"
                 tal:condition="is_tree"
       ><option id="${group_item/id}"
                 selected="${python:'selected' if group_item['selected'] else None}"

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -673,7 +673,7 @@ class SelectWidgetTests(unittest.TestCase):
             "Top level vocab item rendered as <option...>",
         )
         # required select must not allow novalue option
-        self.assertNotIn("select2-test-widget-novalue", html)
+        self.assertNotIn("select-test-widget-novalue", html)
         self.assertIn(
             '<optgroup label="Foo Group"',
             html,
@@ -689,6 +689,7 @@ class SelectWidgetTests(unittest.TestCase):
         # test selected value
         widget.value = ("grault_group",)
         html = widget.render()
+        self.assertIn('selected="selected" value="grault_group"', html)
 
 
 class Select2WidgetTests(unittest.TestCase):
@@ -1036,6 +1037,7 @@ class Select2WidgetTests(unittest.TestCase):
         # test selected value
         widget.value = ("grault_group",)
         html = widget.render()
+        self.assertIn('selected="selected" value="grault_group"', html)
 
 
 class AjaxSelectWidgetTests(unittest.TestCase):

--- a/plone/app/z3cform/tests/test_widgets.py
+++ b/plone/app/z3cform/tests/test_widgets.py
@@ -687,7 +687,7 @@ class SelectWidgetTests(unittest.TestCase):
         self.assertEqual(html.count("select-test-widget-novalue"), 1)
 
         # test selected value
-        widget.value = ("grault_group", )
+        widget.value = ("grault_group",)
         html = widget.render()
 
 
@@ -1034,7 +1034,7 @@ class Select2WidgetTests(unittest.TestCase):
         self.assertEqual(html.count("select2-test-widget-novalue"), 1)
 
         # test selected value
-        widget.value = ("grault_group", )
+        widget.value = ("grault_group",)
         html = widget.render()
 
 


### PR DESCRIPTION
fixes #235 
fixes #225 

Note: the correct vocab term definition for `TreeVocabulary.fromDict` is a 3-value tuple: `(value, token, title)` otherwise you don't get the title in the selector ... see tests as example: https://github.com/plone/plone.app.z3cform/pull/236/files#diff-ae663d5ec04abc1eeb5d5f36aeb1452a80a7f7a1b59eafffe5ed9d0d6db171f2R644-R655 and also the implementation in `example.contenttype` https://github.com/collective/example.contenttype/pull/10