### PR TITLE
Use navigation root instead of site root in content browser widget.

### DIFF
--- a/news/276.bugfix.rst
+++ b/news/276.bugfix.rst
@@ -1,0 +1,3 @@
+Use navigation root instead of site root in content browser widget.
+Otherwise the widget may fail when used within a navigation root (like in a multilingual site).
+[maurits]

--- a/src/plone/app/z3cform/widgets/contentbrowser.py
+++ b/src/plone/app/z3cform/widgets/contentbrowser.py
@@ -79,11 +79,11 @@ def get_contentbrowser_options(
     options["basePath"] = "/".join(base_path_context.getPhysicalPath())
 
     # rootPath - Only display breadcrumb elements deeper than this path.
-    options["rootPath"] = "/".join(site.getPhysicalPath()) if site else "/"
+    options["rootPath"] = "/".join(nav_root.getPhysicalPath()) if nav_root else "/"
 
     # rootUrl: Visible URL up to the rootPath. This is prepended to the
     # currentPath to generate submission URLs.
-    options["rootUrl"] = site.absolute_url() if site else ""
+    options["rootUrl"] = nav_root.absolute_url() if nav_root else ""
 
     # contextPath - current edited object. Will not be available to select.
     options["contextPath"] = "/".join(context.getPhysicalPath())


### PR DESCRIPTION
Otherwise the widget may fail when used within a navigation root (like in a multilingual site).

Fixes https://github.com/plone/plone.app.z3cform/issues/276

I thought about doing the same in the related items widget, but then a test failed because it got an unexpected root path.  And I did not yet see a problem with the related items widget.

I do wonder though if we should only do this fix in the content browser when we use `getSource`.  So adapt the [pattern options here](https://github.com/plone/plone.app.z3cform/blob/5.0.0/src/plone/app/z3cform/widgets/contentbrowser.py#L198-L202).

The reason is that my current fix has a side effect.  Within a navigation root, edit a page and simply edit the standard text field and add a link there.  With my fix, you can only select items within the navigation root.  _Without_ my fix, in the first "results tab", you see the contents of the Plone Site root, and it is working fine.

So with my fix, you can no longer select content from another navigation root, or from the Plone site root.  I guess that is fine, but maybe some people don't like it.

That makes me wonder if instead we should fix something in `plone.app.content`, where the `getSource` view is defined.  But my fix works for me, so for me it is fine.

cc @erral because I see this problem in a multilingual site.


